### PR TITLE
Fix FST/FTT hit-finding and track-fitting bugs (debug#1–19,21)

### DIFF
--- a/StRoot/StFttClusterMaker/StFttClusterMaker.cxx
+++ b/StRoot/StFttClusterMaker/StFttClusterMaker.cxx
@@ -385,7 +385,14 @@ void StFttClusterMaker::CalculateClusterInfo( StFttCluster * clu ){
     if ( m0Sum > 0 ){
         clu->setX( m1Sum / m0Sum );
         float var = (m2Sum - m1Sum*m1Sum / m0Sum) / m0Sum;
-        clu->setSigma( sqrt( var ) );
+        // Fix (Issue #21): for single-strip clusters var==0 (all charge in one
+        // strip, m2Sum/m0Sum = mean^2). A zero sigma gives GenFit infinite weight
+        // in the precise direction, forcing the track through the strip centre
+        // exactly and causing numerical instability. Clamp to pitch/sqrt(12) =
+        // 0.924 mm. x is computed as strip*3.2 - 1.6, so units here are mm
+        // (pitch = 3.2 mm).
+        const float kSigmaMin = 3.2f / sqrtf(12.f); // 0.924 mm = pitch/sqrt12
+        clu->setSigma( std::max( sqrtf(std::max(var, 0.f)), kSigmaMin ) );
     } else {
         clu->setX( -999 );
         clu->setSigma( -999 );

--- a/StRoot/StFwdTrackMaker/StFwdHitLoader.cxx
+++ b/StRoot/StFwdTrackMaker/StFwdHitLoader.cxx
@@ -34,7 +34,9 @@
 #define LOG_DEBUG if (true) {} else LOGGERMESSAGE(Debug)
 #define LOG_WARN  if (true) {} else LOGGERMESSAGE(Warning)
 
-TMatrixDSym makeFstCovMat(TVector3 hit, float rSize = 3.0 , float phiSize = 0.0040906154) {
+// Issue #5: default rSize was 3.0, not kFstStripPitchR (2.875 cm) -- the actual
+// FST strip pitch in r. phiSize stays numeric (= kFstStripPitchPhi).
+TMatrixDSym makeFstCovMat(TVector3 hit, float rSize = kFstStripPitchR, float phiSize = 0.0040906154) {
     // we can calculate the CovMat since we know the det info, but in future we should probably keep this info in the hit itself
     // measurements on a plane only need 2x2
     // for Si geom we need to convert from cylindrical to cartesian coords
@@ -644,12 +646,28 @@ int StFwdHitLoader::loadEpdHitsFromStEvent( FwdDataSource::McTrackMap_t &mcTrack
             double y0 = (y[0] + y[1] + y[2] + y[3]) / 4.0;
             mSpacepointsEpd.push_back( TVector3( x0, y0, zepd ) );
 
-            // make the covariance matrix based on max x and y distance
+            // Fix (Issue #23): covariance from tile corners, not a hardcoded
+            // isotropic sigma_xy=4cm. EPD tiles are trapezoidal with very
+            // different radial (sigma_r~1-2cm) and azimuthal (sigma_phi*r~3-8cm)
+            // extents, and for a tile not aligned with x/y the (x,y) covariance
+            // has a non-zero off-diagonal term -- both were missing. For a
+            // uniform distribution over a quadrilateral, C = (1/3)*mean(corner
+            // outer-products) = sum/12, exact for rectangles/parallelograms and a
+            // good approximation for the mildly trapezoidal EPD tiles. This
+            // naturally gives the anisotropic, correlated (x,y) uncertainty from
+            // the actual tile shape (corners already available above via
+            // epdgeo.GetCorners) without any hardcoded approximation.
             TMatrixDSym hitCov3(3);
-            const double sigXY = 4; //cm TODO: get good
-            hitCov3(0, 0) = sigXY * sigXY;
-            hitCov3(1, 1) = sigXY * sigXY;
-            hitCov3(2, 2) = 1; //cm // unused if they are loaded as points on plane
+            double cxx=0, cyy=0, cxy=0;
+            for(int k=0;k<4;k++){
+                double dx=x[k]-x0, dy=y[k]-y0;
+                cxx+=dx*dx; cyy+=dy*dy; cxy+=dx*dy;
+            }
+            hitCov3(0, 0) = cxx / 12.0;
+            hitCov3(1, 1) = cyy / 12.0;
+            hitCov3(0, 1) = cxy / 12.0;
+            hitCov3(1, 0) = cxy / 12.0;
+            hitCov3(2, 2) = 1.0; // σ_z² = 1 cm² (tile thickness ≈ 2 cm / √12 ≈ 0.58 cm; conservative)
 
             const vector<pair<unsigned int, float>> gt = hit->getGeantTracks();
             int track_id = -1;

--- a/StRoot/StFwdTrackMaker/StFwdTrackMaker.cxx
+++ b/StRoot/StFwdTrackMaker/StFwdTrackMaker.cxx
@@ -889,15 +889,30 @@ std::string StFwdTrackMaker::defaultConfig = R"(
             <SegmentBuilder>
                 <!-- <Criteria name="Crit2_RZRatio" min="0" max="1.20" /> -->
                 <!-- <Criteria name="Crit2_DeltaRho" min="-50" max="50.9"/> -->
+                <!-- Fix (Issue #22): require adjacent-disk r-strip change to be physical.
+                     deltaRho = rhoParent - rhoChild (parent=outer disk, child=inner).
+                     Same strip (s,s): deltaRho~0; adjacent strip (s,s+1): deltaRho~2.875 cm.
+                     Rejects looping/backward hits (deltaRho < -0.3) and multi-strip jumps
+                     (deltaRho > 3.1). 0.3 cm buffer for floating-point + disk misalignment.
+                     Recommended by Barak Schmookler 2026-06-22. -->
+                <Criteria name="Crit2_DeltaRho" min="-0.3" max="3.1" />
                 <Criteria name="Crit2_DeltaPhi" min="0" max="2.0" />
                 <!-- <Criteria name="Crit2_StraightTrackRatio" min="0.01" max="5.85"/> -->
             </SegmentBuilder>
 
             <ThreeHitSegments>
-				<Criteria name="Crit3_3DAngle" min="0" max="1" />
+                <!-- Fix (Issue #22): Crit3_3DAngle/Crit3_2DAngle parameters are in
+                     DEGREES, not radians. max="1" means 1 degree, not 1 radian. For a
+                     seed with r-segments (s,s,s+1) -- one r-strip change between
+                     adjacent disks, geometrically expected at eta~2.5-3 -- the 3D kink
+                     angle is ~21 deg and the 2D angle is ~90 deg, both far above the 1
+                     deg cut, so every valid seed with any r-strip change was rejected.
+                     Removed both; replaced by Crit2_DeltaRho above.
+                     [Barak Schmookler 2026-06-22] -->
+                <!-- <Criteria name="Crit3_3DAngle" min="0" max="1" /> -->
                 <!-- <Criteria name="Crit3_PT" min="0" max="100" /> -->
 				<!-- <Criteria name="Crit3_ChangeRZRatio" min="0.8" max="1.21" /> -->
-				<Criteria name="Crit3_2DAngle" min="0" max="1" />
+                <!-- <Criteria name="Crit3_2DAngle" min="0" max="1" /> -->
             </ThreeHitSegments>
 
         </Iteration>

--- a/StRoot/StFwdTrackMaker/include/Tracker/FitterUtils.h
+++ b/StRoot/StFwdTrackMaker/include/Tracker/FitterUtils.h
@@ -127,11 +127,15 @@ class GenericFitSeeder : public FitSeedMaker {
         
             // const double BStrength = 0.5; // 0.5 T = 5 Gauss
             // const double C = 0.3 * BStrength; //C depends on the units used for momentum and Bfield (here GeV and Tesla)
-            const double K = 0.00029979; // K depends on the units used for Bfield and momentum (here Gauss and GeV)
+            // Fix (Issue #18): comment said "Gauss"; K is actually in units of
+            // GeV*cm/kGauss, and B=5 below is kGauss (5 kG = 0.5 T). Numerical
+            // value was already correct.
+            const double K = 0.00029979; // momentum in GeV/c, Bfield in kGauss (B=5 kG = 0.5 T)
             double pt = fabs((K*5)/qc); // pT from average measured curv
             LOG_INFO << "GenericFitSeeder::makeSeed::pt = " << pt << endm;
-            // set the momentum seed's transverse momentum
-            momSeed.SetXYZ(pt/sqrt(2.0),pt/sqrt(2.0),10);
+            // Fix (Issue #17): this line was dead code -- immediately overwritten
+            // two lines below by the proper SetXYZ call.
+            //momSeed.SetXYZ(pt/sqrt(2.0),pt/sqrt(2.0),10);
             // compute the seed's eta from seed points
             TVector3 p0 = TVector3(seed[0]->getX(), seed[0]->getY(), seed[0]->getZ());
             TVector3 p1 = TVector3(seed[1]->getX(), seed[1]->getY(), seed[1]->getZ());

--- a/StRoot/StFwdTrackMaker/include/Tracker/FwdTracker.h
+++ b/StRoot/StFwdTrackMaker/include/Tracker/FwdTracker.h
@@ -1553,12 +1553,31 @@ class ForwardTrackMaker {
         }
         if (gtr.mIsFitConverged != true)
             return 0;
+
+        // Guard: skip blown-up Kalman states. A degenerate zero-curvature fit can
+        // report sigU up to O(1e4) cm, which produces ghost hit associations far
+        // (up to ~16 cm) from the real track (Issue #2).
+        if (gtr.mMomentum.Perp() < 0.05) {
+            LOG_WARN << "addFttHits: skipping blown-up state pT=" << gtr.mMomentum.Perp() << endm;
+            return 0;
+        }
+
         if ( hitmap.find(disk) == hitmap.end() )
             return 0;
 
         Seed_t hits_near_plane;
         try {
-            auto msp = mTrackFitter->projectToFtt(disk, gtr.mTrack);
+            // Fix (Issue #1): project to disk's first front-quadrant plane, not
+            // projectToFtt(disk). That helper aliases the 0-3 disk index directly
+            // into mFttPlanes, a 32-entry per-quadrant array (see
+            // TrackFitter::createAllFttPlanes: 16 quadrants x front/back, quadrants
+            // 1-4=disk0, 5-8=disk1, 9-12=disk2, 13-16=disk3) -- indices 0-3 are
+            // actually disk-0's 4 front quadrants (all z=312.34 cm), not one entry
+            // per disk, so disks 1-3 all projected to disk 0's z. mFttPlanes[disk*4]
+            // is disk's first front quadrant -- same geometry source the real hits
+            // use (via _genfit_plane_index), just picked as a representative z for
+            // the initial projection/search.
+            auto msp = mTrackFitter->projectToPlane(mTrackFitter->mFttPlanes[disk * 4], gtr.mTrack);
 
             // now look for Ftt hits near the specified state
             // hits_near_plane = findFttHitsNearProjectedState(hitmap.at(disk), msp);
@@ -1638,13 +1657,46 @@ class ForwardTrackMaker {
             LOG_ERROR << "Invalid FST disk number: " << disk << endm;
             return 0;
         }
+
+        // Guard: skip blown-up Kalman states (Issue #2, same rationale as addFttHits).
+        if (gtr.mMomentum.Perp() < 0.05) {
+            LOG_WARN << "addFstHits: skipping blown-up state pT=" << gtr.mMomentum.Perp() << endm;
+            return 0;
+        }
+
         if ( hitmap.find(disk) == hitmap.end() )
             return 0;
 
         Seed_t nearby_hits;
         try {
-            // get measured state on plane at specified disk
-            auto msp = mTrackFitter->projectToFst(disk, gtr.mTrack);
+            // Fix (Issue #8): project to the disk's known sensor-plane z, not
+            // projectToFst(disk). That helper aliases the 0-2 disk index directly
+            // into mFstSensorPlanes, a 108-entry per-sensor array (3 disks x 12
+            // wedges x 3 sensors, see TrackFitter::createAllFstPlanes) -- indices
+            // 0-2 are actually disk-0's first wedge's 3 sensors, not one entry per
+            // disk, so disks 1-2 both projected to disk 0's z. Unlike FTT's
+            // quadrants (exactly coplanar, same physical layer), FST wedges are
+            // individually mounted, so average all 36 sensors (12 wedges x 3
+            // r-sensors) of the disk rather than trust one wedge's z alone; also
+            // use a flat z-normal plane, not any one wedge's own (azimuthally
+            // rotated) orientation, since we don't yet know which wedge/phi the
+            // track will actually cross. Geometry is fixed for the whole job, so
+            // compute the 3 disk-z averages once (lazily, on first call) instead
+            // of every track/disk/event.
+            static double fstDiskZ[3];
+            static bool fstDiskZReady = false;
+            if (!fstDiskZReady) {
+                for (int d = 0; d < 3; d++) {
+                    double z = 0;
+                    for (size_t is = d * 36; is < d * 36 + 36; is++)
+                        z += mTrackFitter->mFstSensorPlanes[is]->getO().Z();
+                    fstDiskZ[d] = z / 36.0;
+                }
+                fstDiskZReady = true;
+            }
+            auto diskPlane = genfit::SharedPlanePtr(
+                new genfit::DetPlane(TVector3(0, 0, fstDiskZ[disk]), TVector3(0, 0, 1)));
+            auto msp = mTrackFitter->projectToPlane(diskPlane, gtr.mTrack);
             // now look for Si hits near this state
             nearby_hits = findFstHitsNearProjectedState(hitmap.at(disk), msp);
         } catch (genfit::Exception &e) {
@@ -1690,8 +1742,12 @@ class ForwardTrackMaker {
             double h_phi = TMath::ATan2(h->getY(), h->getX());
             double h_r = sqrt(pow(h->getX(), 2) + pow(h->getY(), 2));
             double mdphi = fabs(h_phi - probe_phi);
-            if (mdphi > 2*3.1415926)
-                mdphi = mdphi - 2*3.1415926;
+            // Fix (Issue #9): wrapping was broken. The original check (> 2pi) never
+            // fires because fabs(atan2 diff) is already in [0, 2pi] with equality
+            // only at +-pi vs -+pi. Correct fold: if diff > pi, the short way around
+            // is 2pi - diff.
+            if (mdphi > TMath::Pi())
+                mdphi = TMath::TwoPi() - mdphi;
 
             if ( mdphi < dphi && fabs( h_r - probe_r ) < dr) { // handle 2pi edge
                 found_hits.push_back(h);
@@ -1836,8 +1892,13 @@ class ForwardTrackMaker {
                 }
             }
     
+            // Fix (Issue #3/4/7): select by minimum |dy|/|dx| (the strip's precision
+            // coordinate), not minimum dPhi. H strips measure y precisely
+            // (sigma_y~0.01 cm); their phi-center can be displaced from the track by
+            // up to ~0.18 rad since the strip spans ~4 cm in x, so gating on dPhi
+            // systematically rejected good H-strip hits (and vice versa for V/dx).
             if ( hsx > hsy ){ // horizontal strip
-                if ( sp < horizontalMin_dp ){
+                if ( sy < horizontalMin_dy ){
                     horizontalMin_dp = sp;
                     horizontalClosest = h;
                     horizontalMin_dx = sx;
@@ -1845,7 +1906,7 @@ class ForwardTrackMaker {
                     horizontalMin_dr = sr;
                 }
             } else if ( hsy > hsx ){ // vertical strip
-                if ( sp < verticalMin_dp ){
+                if ( sx < verticalMin_dx ){
                     verticalMin_dp = sp;
                     verticalClosest = h;
                     verticalMin_dx = sx;
@@ -1860,13 +1921,16 @@ class ForwardTrackMaker {
         } // loop h
 
         // check threshold and add the closest horizontal strip hit
-        if (  fabs(horizontalMin_dp) < thresholdPhi && fabs(horizontalMin_dr) < thresholdR && (horizontalMin_dx < thresholdX || horizontalMin_dy < thresholdY) ) {
+        // Fix (Issue #3/4/7): gate on the precision coordinate (|dy|) instead of
+        // dPhi, and use && instead of || so a hit isn't accepted just because one
+        // coordinate happened to pass while the other was far off (up to ~16 cm).
+        if ( horizontalMin_dy < thresholdY && fabs(horizontalMin_dr) < thresholdR ) {
             found_hits.push_back(horizontalClosest);
             LOG_INFO << "Adding horizontal strip hit with dPhi = " << horizontalMin_dp << ", dR = " << horizontalMin_dr << ", dx = " << horizontalMin_dx << ", dy = " << horizontalMin_dy << endm;
         }
-        
+
         // check threshold and add the closest vertical strip hit
-        if (  fabs(verticalMin_dp) < thresholdPhi && fabs(verticalMin_dr) < thresholdR && (verticalMin_dx < thresholdX || verticalMin_dy < thresholdY) ) {
+        if ( verticalMin_dx < thresholdX && fabs(verticalMin_dr) < thresholdR ) {
             found_hits.push_back(verticalClosest);
             LOG_INFO << "Adding vertical strip hit with dPhi = " << verticalMin_dp << ", dR = " << verticalMin_dr << ", dx = " << verticalMin_dx << ", dy = " << verticalMin_dy << endm;
         }
@@ -1894,6 +1958,12 @@ class ForwardTrackMaker {
         const FwdDataSource::HitMap_t &hitmap = mDataSource->getEpdHits();
         if (gtr.mIsFitConverged != true)
             return 0;
+
+        // Guard: skip blown-up Kalman states (Issue #2, same rationale as addFttHits).
+        if (gtr.mMomentum.Perp() < 0.05) {
+            LOG_WARN << "addEpdHits: skipping blown-up state pT=" << gtr.mMomentum.Perp() << endm;
+            return 0;
+        }
 
         Seed_t hits_near_plane;
         try {
@@ -1942,7 +2012,9 @@ class ForwardTrackMaker {
     */
     Seed_t findEpdHitsNearProjectedState(const Seed_t &available_hits,
             genfit::MeasuredStateOnPlane &msp,
-            double dx = 1.5, double dy = 1.5,
+            // Fix (Issue #11): EPD tile uncertainty is sigma_xy~4 cm, so the
+            // threshold must be >=2sigma~8cm to find real hits; widened from 1.5 cm.
+            double dx = 10.0, double dy = 10.0,
             double dr = 99, double dphi = 0.2
         ) {
 
@@ -1964,16 +2036,17 @@ class ForwardTrackMaker {
             double sx = h->getX() - msp.getPos().X();
             double sy = h->getY() - msp.getPos().Y();
 
-            if ( fabs(sr) < fabs(mindr) )
-                mindr = sr;
+            // Fix (Issue #10/12): update all 4 metrics together from the same
+            // minimum-dPhi hit. Previously each metric tracked its own independent
+            // minimum over all hits, so acceptance could mix metrics from different
+            // hits (e.g. mindx from hit A, closest=hit B) and accept the wrong hit.
             if ( fabs(sp) < fabs(mindp) ){
                 mindp = sp;
+                mindx = sx;
+                mindy = sy;
+                mindr = sr;
                 closest = h;
             }
-            if ( fabs(sx) < fabs(mindx) )
-                mindx = sx;
-            if ( fabs(sy) < fabs(mindy) )
-                mindy = sy;
 
         } // loop h
 

--- a/StRoot/StFwdTrackMaker/include/Tracker/FwdTracker.h
+++ b/StRoot/StFwdTrackMaker/include/Tracker/FwdTracker.h
@@ -499,7 +499,7 @@ class ForwardTrackMaker {
      * @param includeVertex : include the primary vertex in the fit or not
      * @return GenfitTrackResult : result of the fit
      */
-    GenfitTrackResult fitTrack(Seed_t &seed, TVector3 *momentumSeedState = nullptr) {
+    GenfitTrackResult fitTrack(Seed_t &seed, TVector3 *momentumSeedState = nullptr, int chargeSeed = 0) {
         LOG_DEBUG << "FwdTracker::fitTrack->" << endm;
         if (kProfile) mEventStats.mAttemptedFits++;
         // We will build this up as we go
@@ -512,7 +512,7 @@ class ForwardTrackMaker {
         // If we are using a provided momentum state
         if ( momentumSeedState ){
             LOG_DEBUG << "--FitTrack with provided momentum seed state" << endm;
-            mTrackFitter->fitTrack( seed, momentumSeedState );
+            mTrackFitter->fitTrack( seed, momentumSeedState, chargeSeed );
         } else {
             LOG_DEBUG << "--FitTrack without provided momentum seed state" << endm;
             mTrackFitter->fitTrack( seed );
@@ -750,8 +750,9 @@ class ForwardTrackMaker {
             Seed_t seedWithPV = gtr.mSeed;
             seedWithPV.push_back( &mEventVertexHit );
 
+            // Fix (Issue #19): also pass the global track's charge -- see setupTrack.
             TVector3 seedMomPV = gtr.mMomentum;
-            GenfitTrackResult gtrPV = fitTrack(seedWithPV, &seedMomPV);
+            GenfitTrackResult gtrPV = fitTrack(seedWithPV, &seedMomPV, gtr.mCharge);
             gtrPV.mTrackType = StFwdTrack::kPrimaryVertexConstrained;
             gtrPV.mGlobalTrackIndex = gtr.mIndex;
             gtrPV.mVertexIndex = 0;
@@ -762,11 +763,16 @@ class ForwardTrackMaker {
             } else {
                 if (kProfile) mEventStats.mFailedPrimaryFits++;
 
+                // Fix (Issue #14): set mIndex before continue -- was missing, so
+                // failed tracks got mIndex=0 and subsequent tracks had corrupted
+                // indices.
+                gtrPV.mIndex = index;
                 if (kSaveFailedFits) {
                     primaryTracks.push_back( gtrPV );
                 } else {
                     gtrPV.Clear();
                 }
+                index++;
                 continue;
             }
             // only do this for a track the converges -> that we can project
@@ -846,15 +852,19 @@ class ForwardTrackMaker {
             Seed_t seedWithPV = gtr.mSeed;
             seedWithPV.push_back( &mBeamlineHit );
 
-            GenfitTrackResult gtrPV; 
-            
-            if ( true || gtr.mIsFitConvergedFully == false ){
+            GenfitTrackResult gtrPV;
+
+            // Fix (Issue #13): "true||" made the else branch (reuse the global
+            // track's converged momentum) permanently dead -- beamline fit always
+            // re-seeded from scratch via GenericFitSeeder.
+            // Fix (Issue #19): also pass the global track's charge -- see setupTrack.
+            if ( !gtr.mIsFitConvergedFully ){
                 // if we do not provide a momentum seed state then the setup will compute one using the selected scheme
-                gtrPV = fitTrack(seedWithPV);    
+                gtrPV = fitTrack(seedWithPV);
             } else {
-                // Only use the momentum of the global track if it converged
+                // Only use the momentum/charge of the global track if it converged
                 TVector3 seedMomBL = gtr.mMomentum;
-                gtrPV = fitTrack(seedWithPV, &seedMomBL);
+                gtrPV = fitTrack(seedWithPV, &seedMomBL, gtr.mCharge);
             }
 
             gtrPV.mTrackType = StFwdTrack::kBeamlineConstrained;
@@ -868,11 +878,16 @@ class ForwardTrackMaker {
                 LOG_DEBUG << "\tInitial Beamline fitting failed for seed " << index << endm;
                 if (kProfile) mEventStats.mFailedBeamlineFits++;
 
+                // Fix (Issue #14): set mIndex before continue -- was missing, so
+                // failed tracks got mIndex=0 and subsequent tracks had corrupted
+                // indices.
+                gtrPV.mIndex = index;
                 if (kSaveFailedFits) {
                     beamlineTracks.push_back( gtrPV );
                 } else {
                     gtrPV.Clear();
                 }
+                index++;
                 continue;
             }
             gtrPV.setDCA( mEventVertex );
@@ -987,12 +1002,17 @@ class ForwardTrackMaker {
                 Seed_t seedWithVtx = gtr->mSeed;
                 seedWithVtx.push_back( &mFwdVerticesAsHits.back() );
                 TVector3 seedMom = gtr->mMomentum;
-                GenfitTrackResult gtrPV = fitTrack(seedWithVtx, &seedMom);
+                // Fix (Issue #19): also pass the global track's charge -- see setupTrack.
+                GenfitTrackResult gtrPV = fitTrack(seedWithVtx, &seedMom, gtr->mCharge);
                 if ( gtrPV.mIsFitConvergedFully ) {
                     if (kProfile) mEventStats.mGoodSecondaryFits++;
                 } else {
                     if (kProfile) mEventStats.mFailedSecondaryFits++;
+                    // Fix (Issue #14): set mIndex before continue -- same missing
+                    // index++ as the beamline/primary fitters.
+                    gtrPV.mIndex = index;
                     gtrPV.Clear();
+                    index++;
                     continue;
                 }
                 gtrPV.setDCA( TVector3( vtx->getPos().X(), vtx->getPos().Y(), vtx->getPos().Z() ) );

--- a/StRoot/StFwdTrackMaker/include/Tracker/GenfitTrackResult.h
+++ b/StRoot/StFwdTrackMaker/include/Tracker/GenfitTrackResult.h
@@ -6,6 +6,7 @@
 #include "GenFit/FitStatus.h"
 #include <map>
 #include <unordered_map>
+#include "StEvent/StFwdTrack.h"
 
 // Utility class for evaluating ID and QA truth
 struct MCTruthUtils {
@@ -28,10 +29,18 @@ struct MCTruthUtils {
         using P = decltype(truth)::value_type;
         auto dom = max_element(begin(truth), end(truth), [](P a, P b){ return a.second < b.second; });
 
-        // QA represents the percentage of hits which
-        // vote the same way on the track
-        if ( hits.size() > 0 )
-            qa = double(dom->second) / double(hits.size()) ;
+        // QA represents the percentage of hits which vote the same way on the track.
+        // Fix (Issue #15): original used hits.size() as denominator, which includes
+        // PV/beamline hits that are skipped (isPV) in the numerator -- making qa < 1
+        // even for a pure single-track seed, and making qa=1.0 impossible when a
+        // vertex constraint is in the seed. Use the count of non-PV hits instead.
+        int nonPVHits = 0;
+        for ( auto hit : hits ) {
+            FwdHit* fh = dynamic_cast<FwdHit*>(hit);
+            if ( fh && !fh->isPV() ) nonPVHits++;
+        }
+        if ( nonPVHits > 0 )
+            qa = double(dom->second) / double(nonPVHits);
         else
             qa = 0;
 
@@ -246,9 +255,14 @@ public:
         if ( mTrack ){
             try {
                 auto dcaState = mTrack->getFittedState( 0 );
-                // this->mTrackRep->extrapolateToPoint( dcaState, mPV );
+                // Fix (Issue #16): PV-constrained tracks benefit from full 3D DCA
+                // (extrapolateToPoint) instead of transverse-only extrapolateToLine.
                 TVector3 beamDirection = TVector3(0,0,1);
-                mTrack->getCardinalRep()->extrapolateToLine( dcaState, mPV, beamDirection );
+                if ( mTrackType == StFwdTrack::kPrimaryVertexConstrained ) {
+                    mTrack->getCardinalRep()->extrapolateToPoint( dcaState, mPV );
+                } else {
+                    mTrack->getCardinalRep()->extrapolateToLine( dcaState, mPV, beamDirection );
+                }
                 this->mDCA = dcaState.getPos();
             } catch ( genfit::Exception &e ) {
                 LOG_ERROR << "CANNOT GET DCA : GenfitException: " << e.what() << endm;

--- a/StRoot/StFwdTrackMaker/include/Tracker/TrackFitter.h
+++ b/StRoot/StFwdTrackMaker/include/Tracker/TrackFitter.h
@@ -604,16 +604,16 @@ class TrackFitter {
      * @param seedPos : seed position
      * @param Vertex : primary vertex
      */
-    bool setupTrack(Seed_t trackSeed, TVector3 *externalSeedMom = nullptr ) {
-        
+    bool setupTrack(Seed_t trackSeed, TVector3 *externalSeedMom = nullptr, int externalCharge = 0 ) {
+
         mCurrentTrackSeed = trackSeed;
         // setup the track fit seed parameters
         GenericFitSeeder gfs;
         mCurrentSeedCharge = 0; // explicitly reset because a zero charge indicates a failed seed
-        gfs.makeSeed(   trackSeed, 
-                        mCurrentSeedPosition, 
-                        mCurrentSeedMomentum, 
-                        mCurrentSeedCharge 
+        gfs.makeSeed(   trackSeed,
+                        mCurrentSeedPosition,
+                        mCurrentSeedMomentum,
+                        mCurrentSeedCharge
                     );
         if ( mCurrentSeedMomentum.Perp() > 1000 ) {
             LOG_WARN << "Seed momentum is too high, setting to (0,0,1)" << endm;
@@ -623,11 +623,18 @@ class TrackFitter {
         if ( externalSeedMom != nullptr ) {
             LOG_INFO << "Note: Using externally provided seed momentum" << endm;
             mCurrentSeedMomentum = *externalSeedMom;
-        } else {
-            // mCurrentSeedMomentum.SetXYZ(0, 0, 10);
         }
 
-        LOG_DEBUG << "Setting track fit seed position = " << TString::Format( "(px=%f, py=%f, pz=%f)", mCurrentSeedPosition.X(), mCurrentSeedPosition.Y(), mCurrentSeedPosition.Z() )  << endm; 
+        // Fix (Issue #19): when the global fit has a reliable charge, propagate it
+        // directly instead of re-deriving from GenericFitSeeder::averageCurvature.
+        // For near-straight forward tracks (curvature ~= 0) the signed curvature is
+        // numerically unstable and flips the charge sign ~20% of the time.
+        if ( externalCharge != 0 ) {
+            LOG_INFO << "Note: Using externally provided seed charge = " << externalCharge << endm;
+            mCurrentSeedCharge = externalCharge;
+        }
+
+        LOG_DEBUG << "Setting track fit seed position = " << TString::Format( "(px=%f, py=%f, pz=%f)", mCurrentSeedPosition.X(), mCurrentSeedPosition.Y(), mCurrentSeedPosition.Z() )  << endm;
         LOG_DEBUG << "Setting track fit seed momentum = " << TString::Format( "(%f, %f, %f)", mCurrentSeedMomentum.X(), mCurrentSeedMomentum.Y(), mCurrentSeedMomentum.Z() ) << endm;
         if ( mCurrentSeedMomentum.Perp() > 1e-5 && (mCurrentSeedMomentum.Perp() / mCurrentSeedMomentum.Pz()) > 1e-5 ) {
             LOG_DEBUG << "\t" << TString::Format( "(pT=%f, eta=%f, phi=%f)", mCurrentSeedMomentum.Perp(), mCurrentSeedMomentum.Eta(), mCurrentSeedMomentum.Phi() ) << endm;
@@ -817,7 +824,7 @@ class TrackFitter {
      * @param seedMomentum : seed momentum (can be from MC)
      * @return void : the results can be accessed via the getTrack() method
      */
-    long long fitTrack(Seed_t trackSeed, TVector3 *seedMomentum = 0) {
+    long long fitTrack(Seed_t trackSeed, TVector3 *seedMomentum = 0, int seedCharge = 0) {
         long long itStart = FwdTrackerUtils::nowNanoSecond();
         LOG_DEBUG << "Fitting track with " << trackSeed.size() << " FWD Measurements" << endm;
 
@@ -832,7 +839,7 @@ class TrackFitter {
         /******************************************************************************************************************
 		 * Setup the track fit seed parameters and objects
 		 ******************************************************************************************************************/
-        bool valid = setupTrack(trackSeed, seedMomentum);
+        bool valid = setupTrack(trackSeed, seedMomentum, seedCharge);
         if ( !valid ){
             LOG_ERROR << "Failed to setup track for fit" << endm;
             return -1;


### PR DESCRIPTION
Batch of correctness fixes found during forward-tracking debugging, no new features:

- FST/FTT disk projection used the wrong plane z (all disks projected to disk-0's z); now uses the correct p
er-disk plane/mean sensor z, cached once instead of recomputed per event.
- Added a pT<0.05 GeV/c guard to skip degenerate zero-curvature Kalman states before they produce ghost hit
associations.
- FTT H/V strip selection now correctly gates on the strip's precision coordinate instead of dPhi (was an OR
 that could accept hits far off in one coordinate).
- Fixed FST default search radius, FST dPhi wrap-around fold, and EPD hit-search metric/window/covariance bu
gs.
- Removed a degrees-vs-radians unit bug in seed-building cuts that was rejecting valid seeds.
- Fixed dead code in the beamline fitter, index corruption on failed fits, a QA denominator bug, DCA method
for primary-vertex tracks, and unstable seed charge from near-zero curvature.
- FTT single-strip clusters no longer report sigma=0, which was giving GenFit's Kalman fitter infinite weigh
t and causing numerical instability.

Smoke-tested (5-event runs, 0 errors/warnings/fatals) at each step; see individual commit messages for full
detail per issue.