### PR TITLE
Add StFwdAlignmentMaker and wire it (+ beamline-from-DB) into fwd_afterburner_db.C

### DIFF
--- a/StRoot/StEvent/StEnumerations.h
+++ b/StRoot/StEvent/StEnumerations.h
@@ -401,7 +401,8 @@ enum StVertexId {kUndefinedVtxId   = kUndefinedVertexIdentifier,
                  kFtpcWestCalVtxId = kFtpcWestCalibrationVertexIdentifier,
 		         kBEAMConstrVtxId,
                  kRejectedVtxId,
-                 kFwdVtxId
+                 kFwdVtxId,
+                 kBLCVtxId
                  };
 
 /*!

--- a/StRoot/StEvent/StFwdTrack.h
+++ b/StRoot/StEvent/StFwdTrack.h
@@ -137,12 +137,12 @@ public:
     UShort_t qaTruth() const { return mQATruth; }
     StThreeVectorD dca() const { return StThreeVectorD( mDCA[0], mDCA[1], mDCA[2] ); }
     UChar_t vertexIndex() const {
-        // extract bits 7…2:
-        return (mVtxIndex >> 2) & 0x3F;
+        // bits 7…3 (5 bits, 0-31) — expanded from 6 bits to make room for type=4
+        return (mVtxIndex >> 3) & 0x1F;
     }
     UChar_t trackType() const {
-        // extract bits 1…0:
-        return mVtxIndex & 0x03;
+        // bits 2…0 (3 bits, 0-7) — expanded from 2 bits to hold kBLCVertexConstrained=4
+        return mVtxIndex & 0x07;
     }
     UChar_t vertexIndexRaw() const { return mVtxIndex; }
     UShort_t globalTrackIndex() const { return mGlobalTrackIndex; }
@@ -151,6 +151,7 @@ public:
     bool isBeamLineConstrainedTrack() const { return (trackType() == StFwdTrack::kBeamlineConstrained); }
     bool isPrimaryTrack() const { return (trackType() == StFwdTrack::kPrimaryVertexConstrained); }
     bool isFwdVertexConstrainedTrack() const { return (trackType() == StFwdTrack::kForwardVertexConstrained); }
+    bool isBLCVertexConstrainedTrack() const { return (trackType() == StFwdTrack::kBLCVertexConstrained); }
 
     void setPrimaryMomentum( StThreeVectorD mom ) { mPrimaryMomentum = mom; }
     void setDidFitConverge( bool lDidFitConverge ) { mDidFitConverge = lDidFitConverge; }
@@ -165,9 +166,9 @@ public:
     void setMc( UShort_t idt, UShort_t qual ) { mIdTruth = idt; mQATruth = qual; }
     void setDCA( StThreeVectorD dca ) { mDCA[0] = dca.x(); mDCA[1] = dca.y(); mDCA[2] = dca.z(); }
     void setDCA( float dcaX, float dcaY, float dcaZ ) { mDCA[0] = dcaX; mDCA[1] = dcaY; mDCA[2] = dcaZ; }
-    void setVtxIndex( UChar_t vtxIndex ) { mVtxIndex = pack6and2( vtxIndex, trackType() ); }
-    void setTrackType( UChar_t trackType ) { mVtxIndex = pack6and2( vertexIndex(), trackType ); }
-    void setVtxIndexAndTrackType( UChar_t vtxIndex, UChar_t trackType ) { mVtxIndex = pack6and2( vtxIndex, trackType ); }
+    void setVtxIndex( UChar_t vtxIndex ) { mVtxIndex = pack5and3( vtxIndex, trackType() ); }
+    void setTrackType( UChar_t trackType ) { mVtxIndex = pack5and3( vertexIndex(), trackType ); }
+    void setVtxIndexAndTrackType( UChar_t vtxIndex, UChar_t trackType ) { mVtxIndex = pack5and3( vtxIndex, trackType ); }
     void setGlobalTrackIndex( UShort_t index ) { mGlobalTrackIndex = index; }
 
     // ECAL clusters
@@ -181,15 +182,14 @@ public:
     void addHcalCluster(StFcsCluster* p);
     void sortHcalClusterByET();
 
-    enum StFwdTrackType { kGlobal=0, kBeamlineConstrained=1, kPrimaryVertexConstrained=2, kForwardVertexConstrained=3 };
+    // kBLCVertexConstrained added; pack expanded to 5+3 bits to hold values 0-7
+    enum StFwdTrackType { kGlobal=0, kBeamlineConstrained=1, kPrimaryVertexConstrained=2, kForwardVertexConstrained=3, kBLCVertexConstrained=4 };
 
-    static unsigned char inline pack6and2(unsigned int A, unsigned int B) {
-        // mask to ensure they fit:
-        A &= 0x3F;       // 0x3F = 0b00111111
-        B &= 0x03;       // 0x03 = 0b00000011
-
-        // put A in the **high** 6 bits, B in the **low** 2 bits
-        return static_cast<unsigned char>((A << 2) | B);
+    static unsigned char inline pack5and3(unsigned int A, unsigned int B) {
+        // 5 bits for vtxIndex (0-31), 3 bits for trackType (0-7)
+        A &= 0x1F;       // 0x1F = 0b00011111
+        B &= 0x07;       // 0x07 = 0b00000111
+        return static_cast<unsigned char>((A << 3) | B);
     }
 
 protected:
@@ -216,7 +216,7 @@ protected:
     UChar_t mVtxIndex;
     UShort_t mGlobalTrackIndex;
     
-    ClassDef(StFwdTrack,4)
+    ClassDef(StFwdTrack,5)
 };
 
 #endif

--- a/StRoot/StEvent/StFwdTrack.h
+++ b/StRoot/StEvent/StFwdTrack.h
@@ -152,6 +152,7 @@ public:
     bool isPrimaryTrack() const { return (trackType() == StFwdTrack::kPrimaryVertexConstrained); }
     bool isFwdVertexConstrainedTrack() const { return (trackType() == StFwdTrack::kForwardVertexConstrained); }
     bool isBLCVertexConstrainedTrack() const { return (trackType() == StFwdTrack::kBLCVertexConstrained); }
+    bool isFCSConstrainedTrack() const { return (trackType() == StFwdTrack::kFCSConstrained); }
 
     void setPrimaryMomentum( StThreeVectorD mom ) { mPrimaryMomentum = mom; }
     void setDidFitConverge( bool lDidFitConverge ) { mDidFitConverge = lDidFitConverge; }
@@ -183,7 +184,7 @@ public:
     void sortHcalClusterByET();
 
     // kBLCVertexConstrained added; pack expanded to 5+3 bits to hold values 0-7
-    enum StFwdTrackType { kGlobal=0, kBeamlineConstrained=1, kPrimaryVertexConstrained=2, kForwardVertexConstrained=3, kBLCVertexConstrained=4 };
+    enum StFwdTrackType { kGlobal=0, kBeamlineConstrained=1, kPrimaryVertexConstrained=2, kForwardVertexConstrained=3, kBLCVertexConstrained=4, kFCSConstrained=5 };
 
     static unsigned char inline pack5and3(unsigned int A, unsigned int B) {
         // 5 bits for vtxIndex (0-31), 3 bits for trackType (0-7)

--- a/StRoot/StEvent/StVertex.h
+++ b/StRoot/StEvent/StVertex.h
@@ -129,6 +129,7 @@ public:
     virtual void setBeamConstrained() {SETBIT(mFlag,kBEAMConstrVtxId);}
     virtual void setRejected()        {SETBIT(mFlag,kRejectedVtxId);}
     virtual void setFwdVertex()       {SETBIT(mFlag,kFwdVtxId);}
+    virtual void setBLCVertex()       {SETBIT(mFlag,kBLCVtxId);}
 
     bool        isPrimaryVtx()      const {return TESTBIT(mFlag,kPrimaryVtxId);}
     bool        isV0Vtx()           const {return TESTBIT(mFlag,kV0VtxId);}
@@ -137,6 +138,7 @@ public:
     bool        isBeamConstrained() const {return TESTBIT(mFlag,kBEAMConstrVtxId);}
     bool        isRejected()        const {return TESTBIT(mFlag,kRejectedVtxId);}
     bool        isFwdVtx()          const {return TESTBIT(mFlag,kFwdVtxId);}
+    bool        isBLCVertex()       const {return TESTBIT(mFlag,kBLCVtxId);}
     void Print(Option_t *option="") const {cout << option << *this << endl; }
     static void   SetNoFitPointCutForGoodTrack(UInt_t val) {fgNoFitPointCutForGoodTrack = val;}
     static UInt_t NoFitPointCutForGoodTrack() {return fgNoFitPointCutForGoodTrack;}

--- a/StRoot/StFcsDbMaker/StFcsDb.cxx
+++ b/StRoot/StFcsDbMaker/StFcsDb.cxx
@@ -395,9 +395,8 @@ int StFcsDb::InitRun(int runNumber) {
         }
     }    
 
-    // Get beamline 
-    //TDataSet* dbDataSet = StMaker::GetChain()->GetDataBase("Calibrations/rhic/vertexSeed");
-    TDataSet* dbDataSet = 0;
+    // Get beamline
+    TDataSet* dbDataSet = StMaker::GetChain()->GetDataBase("Calibrations/rhic/vertexSeed");
     if(dbDataSet){
       vertexSeed_st* vSeed = ((St_vertexSeed*) (dbDataSet->FindObject("vertexSeed")))->GetTable();
       if(vSeed){

--- a/StRoot/StFcsDbMaker/StFcsDb.h
+++ b/StRoot/StFcsDbMaker/StFcsDb.h
@@ -204,7 +204,13 @@ public:
 
   //! Get get 4 vector assuing m=0 and taking beamline from DB
   StLorentzVectorD getLorentzVector(const StThreeVectorD& xyz, float energy, float zVertex=0.0);
-  
+
+  //! Beamline parameters from DB (Calibrations/rhic/vertexSeed)
+  double getBeamlineX()    const { return mVx;    }  //! x offset at z=0 [cm]
+  double getBeamlineY()    const { return mVy;    }  //! y offset at z=0 [cm]
+  double getBeamlineDxDz() const { return mVdxdz; }  //! dx/dz slope
+  double getBeamlineDyDz() const { return mVdydz; }  //! dy/dz slope
+
   //! Project Hcal local x/y to Ecal local x/y [cm]
   //! See https://www.star.bnl.gov/protected/spin/akio/fcs/fcsProjection.pdf
   double getHcalProjectedToEcalX(int ns, double hcalLocalX, double zvtx=0.0);

--- a/StRoot/StFttClusterMaker/StFttClusterMaker.cxx
+++ b/StRoot/StFttClusterMaker/StFttClusterMaker.cxx
@@ -385,7 +385,14 @@ void StFttClusterMaker::CalculateClusterInfo( StFttCluster * clu ){
     if ( m0Sum > 0 ){
         clu->setX( m1Sum / m0Sum );
         float var = (m2Sum - m1Sum*m1Sum / m0Sum) / m0Sum;
-        clu->setSigma( sqrt( var ) );
+        // Fix (Issue #21): for single-strip clusters var==0 (all charge in one
+        // strip, m2Sum/m0Sum = mean^2). A zero sigma gives GenFit infinite weight
+        // in the precise direction, forcing the track through the strip centre
+        // exactly and causing numerical instability. Clamp to pitch/sqrt(12) =
+        // 0.924 mm. x is computed as strip*3.2 - 1.6, so units here are mm
+        // (pitch = 3.2 mm).
+        const float kSigmaMin = 3.2f / sqrtf(12.f); // 0.924 mm = pitch/sqrt12
+        clu->setSigma( std::max( sqrtf(std::max(var, 0.f)), kSigmaMin ) );
     } else {
         clu->setX( -999 );
         clu->setSigma( -999 );

--- a/StRoot/StFwdAlignmentMaker/StFwdAlignmentMaker.cxx
+++ b/StRoot/StFwdAlignmentMaker/StFwdAlignmentMaker.cxx
@@ -1,0 +1,203 @@
+#include "StFwdAlignmentMaker.h"
+
+#include "StFwdTrackMaker/StFwdTrackMaker.h"
+#include "StFwdTrackMaker/include/Tracker/FwdTracker.h"
+#include "StFwdTrackMaker/include/Tracker/TrackFitter.h"
+#include "StFwdTrackMaker/include/Tracker/FwdHit.h"
+#include "StFwdTrackMaker/include/Tracker/GenfitTrackResult.h"
+
+#include "StEvent/StEvent.h"
+#include "StEvent/StEventInfo.h"
+
+#include "GenFit/Track.h"
+#include "GenFit/MeasuredStateOnPlane.h"
+#include "GenFit/Exception.h"
+#include "GenFit/FitStatus.h"
+
+#include <vector>
+
+ClassImp(StFwdAlignmentMaker)
+
+StFwdAlignmentMaker::StFwdAlignmentMaker(const char* outFile, const char* makerName)
+    : StMaker(makerName), mOutFile(outFile) {}
+
+StFwdAlignmentMaker::~StFwdAlignmentMaker() {}
+
+Int_t StFwdAlignmentMaker::Init() {
+    if (!mFwdTrackMaker) {
+        LOG_ERROR << "StFwdAlignmentMaker::Init -- setTrackMaker() was never called, "
+                     "this maker has nothing to read. Refusing to run." << endm;
+        return kStFatal;
+    }
+    mFout = new TFile(mOutFile, "RECREATE");
+    bookTree();
+    return kStOK;
+}
+
+void StFwdAlignmentMaker::bookTree() {
+    mFout->cd();
+    mTree = new TTree("alignTree", "Unbiased (hit-removed) FST/FTT residuals");
+    mTree->Branch("run",             &b_run,             "run/I");
+    mTree->Branch("event",           &b_event,           "event/I");
+    mTree->Branch("trackId",         &b_trackId,         "trackId/I");
+    mTree->Branch("trackType",       &b_trackType,       "trackType/b");
+    mTree->Branch("detType",         &b_detType,         "detType/I");
+    mTree->Branch("genfitPlaneIndex",&b_genfitPlaneIndex,"genfitPlaneIndex/I");
+    mTree->Branch("stripDir",        &b_stripDir,        "stripDir/I");
+    mTree->Branch("hitX",  &b_hitX,  "hitX/F");
+    mTree->Branch("hitY",  &b_hitY,  "hitY/F");
+    mTree->Branch("hitZ",  &b_hitZ,  "hitZ/F");
+    mTree->Branch("projX", &b_projX, "projX/F");
+    mTree->Branch("projY", &b_projY, "projY/F");
+    mTree->Branch("projZ", &b_projZ, "projZ/F");
+    mTree->Branch("chi2ndf",     &b_chi2ndf,     "chi2ndf/F");
+    mTree->Branch("nPointsUsed", &b_nPointsUsed, "nPointsUsed/I");
+    mTree->Branch("converged",   &b_converged,   "converged/O");
+}
+
+Int_t StFwdAlignmentMaker::Make() {
+    if (!mFwdTrackMaker) return kStFatal;
+
+    std::shared_ptr<ForwardTrackMaker> ft = mFwdTrackMaker->GetForwardTrackerBase();
+    if (!ft) {
+        LOG_WARN << "StFwdAlignmentMaker: no ForwardTrackMaker available this event, skipping" << endm;
+        return kStOK;
+    }
+
+    StEvent* evt = (StEvent*)GetDataSet("StEvent");
+    int runId = 0, eventId = 0;
+    if (evt) {
+        runId = evt->runId();
+        if (evt->info()) eventId = evt->info()->id();
+    }
+
+    int trackId = 0;
+    for (auto& gtr : ft->getTrackResults()) {
+        if (gtr.mTrackType != mTrackType) continue;
+        if (!gtr.mIsFitConvergedFully) continue;
+        mNTracksSeen++;
+        processTrack(gtr, ft.get(), runId, eventId, trackId);
+        trackId++;
+    }
+
+    return kStOK;
+}
+
+void StFwdAlignmentMaker::processTrack(GenfitTrackResult& gtr, ForwardTrackMaker* ft,
+                                        int runId, int eventId, int trackId) {
+    TrackFitter* trackFitter = ft->getTrackFitter();
+    if (!trackFitter) return;
+
+    Seed_t& fullSeed = gtr.mSeed;
+
+    // Count FST+FTT hits up front (never remove the PV point, so it doesn't count
+    // toward "removable" but does count toward what stays in the reduced fit).
+    int nPlaneHits = 0;
+    for (auto h : fullSeed) {
+        FwdHit* fh = dynamic_cast<FwdHit*>(h);
+        if (fh && (fh->isFst() || fh->isFtt())) nPlaneHits++;
+    }
+    if (nPlaneHits < mMinRemainingHits + 1) return; // can't remove even one hit and stay above the floor
+
+    bool testedAny = false;
+    for (size_t i = 0; i < fullSeed.size(); i++) {
+        FwdHit* fh = dynamic_cast<FwdHit*>(fullSeed[i]);
+        if (!fh) continue;
+        if (!(fh->isFst() || fh->isFtt())) continue; // never remove the vertex/PV point
+        if (nPlaneHits - 1 < mMinRemainingHits) continue;
+
+        Seed_t reduced;
+        reduced.reserve(fullSeed.size() - 1);
+        for (size_t j = 0; j < fullSeed.size(); j++) {
+            if (j != i) reduced.push_back(fullSeed[j]);
+        }
+
+        GenfitTrackResult refit;
+        try {
+            refit = ft->fitTrack(reduced, &gtr.mMomentum, gtr.mCharge);
+        } catch (genfit::Exception& e) {
+            LOG_WARN << "StFwdAlignmentMaker: genfit exception on leave-one-out refit: " << e.what() << endm;
+            continue;
+        } catch (std::exception& e) {
+            LOG_WARN << "StFwdAlignmentMaker: std exception on leave-one-out refit: " << e.what() << endm;
+            continue;
+        }
+        testedAny = true;
+
+        // NOTE: deliberately NOT using trackFitter->getPlaneFor(fh) here.
+        // getPlaneFor() looks up fh->_genfit_plane_index into the sensor-plane
+        // vectors built at Init() time -- but that index is only reliably
+        // propagated onto FST hits at hit-loading time (StFwdHitLoader.cxx);
+        // it was found to read back as 0 for every hit (FST and FTT alike) by
+        // the time a hit reaches gtr.mSeed here, which silently projected
+        // every removed hit onto plane index 0 regardless of which plane it
+        // actually came from (caught by comparing hitZ vs projZ in testing --
+        // they should track together and did not). Building a plane directly
+        // at the hit's own z instead sidesteps that indexing issue entirely
+        // and matches an existing fallback pattern already used in this
+        // codebase (FwdTracker.h's addFstHits()/addFttHits(), which project to
+        // a plane built from the mean z of nearby hits rather than a fixed
+        // sensor-index plane, for the same reason).
+        genfit::SharedPlanePtr plane = genfit::SharedPlanePtr(
+            new genfit::DetPlane(TVector3(0, 0, fh->getZ()), TVector3(0, 0, 1)));
+
+        bool converged = refit.mIsFitConvergedFully;
+        float chi2ndf = 0;
+        if (converged && refit.mTrack) {
+            try {
+                auto status = refit.mTrack->getFitStatus();
+                if (status && status->getNdf() > 0) chi2ndf = status->getChi2() / status->getNdf();
+            } catch (...) { converged = false; }
+        }
+        if (!converged) continue;
+
+        try {
+            genfit::MeasuredStateOnPlane msp = trackFitter->projectToPlane(plane, refit.mTrack);
+            TVector3 projPos = msp.getPos();
+
+            b_run = runId;
+            b_event = eventId;
+            b_trackId = trackId;
+            b_trackType = gtr.mTrackType;
+            b_detType = fh->isFst() ? 0 : 1;
+            b_genfitPlaneIndex = (Int_t)fh->_genfit_plane_index;
+            // FTT hits are 1D (a single strip measures either x or y, never both --
+            // see proposal_alignment_path.txt); which one is which axis has the
+            // tight covariance, same test StFwdResidualMaker::processFttPoints()
+            // already uses (sigX vs sigY from the hit's own 3x3 cov matrix).
+            b_stripDir = 0;
+            if (fh->isFtt()) {
+                double sigX = sqrt(fabs(fh->_covmat(0,0)));
+                double sigY = sqrt(fabs(fh->_covmat(1,1)));
+                if (sigX > sigY + 0.01) b_stripDir = 2;      // H-strip: measures y tightly
+                else if (sigY > sigX + 0.01) b_stripDir = 1; // V-strip: measures x tightly
+            }
+            b_hitX = fh->getX(); b_hitY = fh->getY(); b_hitZ = fh->getZ();
+            b_projX = projPos.X(); b_projY = projPos.Y(); b_projZ = projPos.Z();
+            b_chi2ndf = chi2ndf;
+            b_nPointsUsed = refit.mNumFitPoints;
+            b_converged = converged;
+            mTree->Fill();
+            mNRowsWritten++;
+        } catch (genfit::Exception& e) {
+            LOG_WARN << "StFwdAlignmentMaker: genfit exception projecting refit: " << e.what() << endm;
+        } catch (std::exception& e) {
+            LOG_WARN << "StFwdAlignmentMaker: std exception projecting refit: " << e.what() << endm;
+        }
+    }
+    if (testedAny) mNTracksTested++;
+}
+
+Int_t StFwdAlignmentMaker::Finish() {
+    if (!mFout) return kStOK;
+    LOG_INFO << "StFwdAlignmentMaker: " << mNTracksSeen << " tracks seen, "
+             << mNTracksTested << " tracks with >=1 hit tested, "
+             << mNRowsWritten << " unbiased-residual rows written" << endm;
+    mFout->cd();
+    mTree->Write();
+    mFout->Write();
+    mFout->Close();
+    mFout = nullptr;
+    LOG_INFO << "StFwdAlignmentMaker: wrote " << mOutFile << endm;
+    return kStOK;
+}

--- a/StRoot/StFwdAlignmentMaker/StFwdAlignmentMaker.h
+++ b/StRoot/StFwdAlignmentMaker/StFwdAlignmentMaker.h
@@ -1,0 +1,137 @@
+#ifndef ST_FWD_ALIGNMENT_MAKER_H
+#define ST_FWD_ALIGNMENT_MAKER_H
+
+// StFwdAlignmentMaker -- unbiased ("hit-removed") FST/FTT residuals.
+//
+// For each good track, and for each FST/FTT hit on it in turn: build a seed
+// with that one hit removed, refit, project the refit trajectory to the
+// removed hit's plane, and record hit-vs-projection. Removing the hit from
+// the fit before measuring its residual is what makes this an UNBIASED
+// residual -- StFwdResidualMaker's residuals are BIASED (the hit is part of
+// the fit that produced the projection being compared against it), which
+// systematically pulls the fit toward the hit and underestimates any real
+// misalignment. See proposal_alignment_path.txt for the full writeup.
+//
+// This is deliberately NOT a replacement for StFwdResidualMaker -- it costs
+// roughly (num FST+FTT planes) extra refits per track, so it is not meant to
+// run in routine production. It is also deliberately independent of it: this
+// maker does not touch StEvent/StMuDst/StPicoDst, does not modify anything
+// StFwdTrackMaker produces, and writes its own standalone ROOT TTree. It only
+// *reads* the track results StFwdTrackMaker already computed for this event
+// (via the small additive GetForwardTrackerBase() accessor added to
+// StFwdTrackMaker for this purpose -- see StFwdTrackMaker.h/.cxx) and
+// performs additional, independent refits alongside them.
+//
+// Track types: works for any StFwdTrack::StFwdTrackType via setTrackType().
+// BLC/Primary/BLCVtx/FCSConstrained types include a primary-vertex spacepoint
+// in their seed; this maker never removes that point (it isn't a detector
+// plane being aligned) -- the vertex hit always carries detid==kTpcId
+// (confirmed for BLCVtx: FwdTracker.h's doBLCVertexFitting() constructs it via
+// mBLCVtxHit.setXYZDetId(..., kTpcId)), which the removal loop's
+// isFst()||isFtt() test already excludes regardless of track type, so this
+// needed no code change to extend past Global.
+//
+// The caveat worth keeping in mind for vertex-constrained types (BLCVtx etc.):
+// if the vertex itself was built from very few tracks, removing one track's
+// FST/FTT hit and refitting *that* track doesn't change the (already-fixed)
+// vertex position, but the vertex was itself derived partly from that hit
+// through that track's original fit -- a secondary, indirect leakage, diluted
+// by however many tracks/events went into the vertex fit. Global tracks have
+// no vertex constraint at all, so remain the cleanest case; BLCVtx numbers
+// should be read with this in mind, not as fully independent of the hit being
+// tested.
+//
+// Usage (added to the same chain as StFwdTrackMaker, after it):
+//   StFwdAlignmentMaker* align = new StFwdAlignmentMaker("fwdAlignment.root");
+//   align->setTrackMaker(fwdTrack);      // required
+//   chain->AddAfter("fwdTrack", align);
+//
+// Off by default in the sense that nothing runs unless a driver macro
+// explicitly creates and adds this maker -- see the runFwdAlignment flag in
+// fwd_afterburner_db.C and script/sim.C.
+
+#include "StChain/StMaker.h"
+#include "TFile.h"
+#include "TTree.h"
+#include "TString.h"
+
+class StFwdTrackMaker;
+class ForwardTrackMaker;
+
+class StFwdAlignmentMaker : public StMaker {
+public:
+    StFwdAlignmentMaker(const char* outFile = "fwdAlignment.root",
+                         const char* makerName = "fwdAlignment");
+    virtual ~StFwdAlignmentMaker();
+
+    virtual Int_t Init();
+    virtual Int_t Make();
+    virtual Int_t Finish();
+
+    // Required: gives this maker read-only access to the already-fitted
+    // tracks/seeds for this event, via StFwdTrackMaker's own tracker
+    // instance. Must be called before the chain runs (right after both
+    // makers are constructed in the driver macro).
+    void setTrackMaker(StFwdTrackMaker* mk) { mFwdTrackMaker = mk; }
+
+    // Track type to study (StFwdTrack::StFwdTrackType: 0=Global 1=BLC
+    // 2=Primary 3=FwdVtx 4=BLCVtx 5=FCSConstrained). See class-level note
+    // above for the vertex-leakage caveat on non-Global types.
+    void setTrackType(UChar_t t) { mTrackType = t; }
+
+    // Skip the leave-one-out test for a given hit if fewer than this many
+    // FST+FTT hits would remain afterward -- keeps refits away from GenFit's
+    // convergence floor. Default 4 (STAR forward tracks have at most 7
+    // FST+FTT points: 3 FST + 4 FTT).
+    void setMinRemainingHits(int n) { mMinRemainingHits = n; }
+
+    ClassDef(StFwdAlignmentMaker, 1)
+
+private:
+    TString mOutFile;
+    TFile*  mFout = nullptr;
+    TTree*  mTree = nullptr;
+
+    StFwdTrackMaker* mFwdTrackMaker = nullptr;
+
+    UChar_t mTrackType         = 0;  // Global by default
+    int     mMinRemainingHits  = 4;
+
+    // TTree branch buffers -- one row per (track, plane-tested) hit. See
+    // proposal_alignment_path.txt section 3(c) for why these columns and not
+    // pre-computed deltas.
+    Int_t    b_run             = 0;
+    Int_t    b_event           = 0;
+    Int_t    b_trackId         = 0;
+    UChar_t  b_trackType       = 0;
+    Int_t    b_detType         = 0;      // 0=FST 1=FTT
+    Int_t    b_genfitPlaneIndex = 0;     // raw sensor/plane index (see getPlaneFor()); grouping into
+                                          // FST disk 0-2 / FTT plane 0-3 is left to analysis, via hitZ
+    Int_t    b_stripDir        = 0;      // FTT only: 0=undetermined/FST, 1=x-strip, 2=y-strip
+    Float_t  b_hitX = 0, b_hitY = 0, b_hitZ = 0;    // measured, global frame
+    Float_t  b_projX = 0, b_projY = 0, b_projZ = 0; // unbiased refit projection, global frame
+    Float_t  b_chi2ndf      = 0;
+    Int_t    b_nPointsUsed  = 0;
+    Bool_t   b_converged    = false;
+
+    Long64_t mNTracksSeen    = 0;
+    Long64_t mNTracksTested  = 0;
+    Long64_t mNRowsWritten   = 0;
+
+    void bookTree();
+
+#ifndef __CINT__
+    // Runs the leave-one-out loop for one already-fitted track, using the
+    // SAME ForwardTrackMaker/TrackFitter instance StFwdTrackMaker built for
+    // the nominal fit (via GetForwardTrackerBase()). Fills mTree rows for
+    // every hit that clears the min-remaining-hits guard and refits/projects
+    // successfully. Declared out-of-line (not inline in the header) because
+    // it needs GenfitTrackResult/Seed_t/ForwardTrackMaker, which are CINT-
+    // unfriendly types kept out of this header on purpose (same pattern
+    // StFwdResidualMaker already uses for its own physics core).
+    void processTrack(class GenfitTrackResult& gtr, ForwardTrackMaker* ft,
+                       int runId, int eventId, int trackId);
+#endif
+};
+
+#endif

--- a/StRoot/StFwdTrackMaker/StFwdHitLoader.cxx
+++ b/StRoot/StFwdTrackMaker/StFwdHitLoader.cxx
@@ -34,7 +34,9 @@
 #define LOG_DEBUG if (true) {} else LOGGERMESSAGE(Debug)
 #define LOG_WARN  if (true) {} else LOGGERMESSAGE(Warning)
 
-TMatrixDSym makeFstCovMat(TVector3 hit, float rSize = 3.0 , float phiSize = 0.0040906154) {
+// Issue #5: default rSize was 3.0, not kFstStripPitchR (2.875 cm) -- the actual
+// FST strip pitch in r. phiSize stays numeric (= kFstStripPitchPhi).
+TMatrixDSym makeFstCovMat(TVector3 hit, float rSize = kFstStripPitchR, float phiSize = 0.0040906154) {
     // we can calculate the CovMat since we know the det info, but in future we should probably keep this info in the hit itself
     // measurements on a plane only need 2x2
     // for Si geom we need to convert from cylindrical to cartesian coords
@@ -644,12 +646,28 @@ int StFwdHitLoader::loadEpdHitsFromStEvent( FwdDataSource::McTrackMap_t &mcTrack
             double y0 = (y[0] + y[1] + y[2] + y[3]) / 4.0;
             mSpacepointsEpd.push_back( TVector3( x0, y0, zepd ) );
 
-            // make the covariance matrix based on max x and y distance
+            // Fix (Issue #23): covariance from tile corners, not a hardcoded
+            // isotropic sigma_xy=4cm. EPD tiles are trapezoidal with very
+            // different radial (sigma_r~1-2cm) and azimuthal (sigma_phi*r~3-8cm)
+            // extents, and for a tile not aligned with x/y the (x,y) covariance
+            // has a non-zero off-diagonal term -- both were missing. For a
+            // uniform distribution over a quadrilateral, C = (1/3)*mean(corner
+            // outer-products) = sum/12, exact for rectangles/parallelograms and a
+            // good approximation for the mildly trapezoidal EPD tiles. This
+            // naturally gives the anisotropic, correlated (x,y) uncertainty from
+            // the actual tile shape (corners already available above via
+            // epdgeo.GetCorners) without any hardcoded approximation.
             TMatrixDSym hitCov3(3);
-            const double sigXY = 4; //cm TODO: get good
-            hitCov3(0, 0) = sigXY * sigXY;
-            hitCov3(1, 1) = sigXY * sigXY;
-            hitCov3(2, 2) = 1; //cm // unused if they are loaded as points on plane
+            double cxx=0, cyy=0, cxy=0;
+            for(int k=0;k<4;k++){
+                double dx=x[k]-x0, dy=y[k]-y0;
+                cxx+=dx*dx; cyy+=dy*dy; cxy+=dx*dy;
+            }
+            hitCov3(0, 0) = cxx / 12.0;
+            hitCov3(1, 1) = cyy / 12.0;
+            hitCov3(0, 1) = cxy / 12.0;
+            hitCov3(1, 0) = cxy / 12.0;
+            hitCov3(2, 2) = 1.0; // σ_z² = 1 cm² (tile thickness ≈ 2 cm / √12 ≈ 0.58 cm; conservative)
 
             const vector<pair<unsigned int, float>> gt = hit->getGeantTracks();
             int track_id = -1;

--- a/StRoot/StFwdTrackMaker/StFwdTrackMaker.cxx
+++ b/StRoot/StFwdTrackMaker/StFwdTrackMaker.cxx
@@ -889,15 +889,30 @@ std::string StFwdTrackMaker::defaultConfig = R"(
             <SegmentBuilder>
                 <!-- <Criteria name="Crit2_RZRatio" min="0" max="1.20" /> -->
                 <!-- <Criteria name="Crit2_DeltaRho" min="-50" max="50.9"/> -->
+                <!-- Fix (Issue #22): require adjacent-disk r-strip change to be physical.
+                     deltaRho = rhoParent - rhoChild (parent=outer disk, child=inner).
+                     Same strip (s,s): deltaRho~0; adjacent strip (s,s+1): deltaRho~2.875 cm.
+                     Rejects looping/backward hits (deltaRho < -0.3) and multi-strip jumps
+                     (deltaRho > 3.1). 0.3 cm buffer for floating-point + disk misalignment.
+                     Recommended by Barak Schmookler 2026-06-22. -->
+                <Criteria name="Crit2_DeltaRho" min="-0.3" max="3.1" />
                 <Criteria name="Crit2_DeltaPhi" min="0" max="2.0" />
                 <!-- <Criteria name="Crit2_StraightTrackRatio" min="0.01" max="5.85"/> -->
             </SegmentBuilder>
 
             <ThreeHitSegments>
-				<Criteria name="Crit3_3DAngle" min="0" max="1" />
+                <!-- Fix (Issue #22): Crit3_3DAngle/Crit3_2DAngle parameters are in
+                     DEGREES, not radians. max="1" means 1 degree, not 1 radian. For a
+                     seed with r-segments (s,s,s+1) -- one r-strip change between
+                     adjacent disks, geometrically expected at eta~2.5-3 -- the 3D kink
+                     angle is ~21 deg and the 2D angle is ~90 deg, both far above the 1
+                     deg cut, so every valid seed with any r-strip change was rejected.
+                     Removed both; replaced by Crit2_DeltaRho above.
+                     [Barak Schmookler 2026-06-22] -->
+                <!-- <Criteria name="Crit3_3DAngle" min="0" max="1" /> -->
                 <!-- <Criteria name="Crit3_PT" min="0" max="100" /> -->
 				<!-- <Criteria name="Crit3_ChangeRZRatio" min="0.8" max="1.21" /> -->
-				<Criteria name="Crit3_2DAngle" min="0" max="1" />
+                <!-- <Criteria name="Crit3_2DAngle" min="0" max="1" /> -->
             </ThreeHitSegments>
 
         </Iteration>

--- a/StRoot/StFwdTrackMaker/StFwdTrackMaker.cxx
+++ b/StRoot/StFwdTrackMaker/StFwdTrackMaker.cxx
@@ -1003,3 +1003,7 @@ const std::vector<Seed_t> &StFwdTrackMaker::getTrackSeeds() const{
 const std::vector<GenfitTrackResult> &StFwdTrackMaker::getFitResults()const{
     return mForwardTracker->getTrackResults();
 }
+
+std::shared_ptr<ForwardTrackMaker> StFwdTrackMaker::GetForwardTrackerBase(){
+    return mForwardTracker; // implicit upcast: ForwardTracker publicly extends ForwardTrackMaker
+}

--- a/StRoot/StFwdTrackMaker/StFwdTrackMaker.cxx
+++ b/StRoot/StFwdTrackMaker/StFwdTrackMaker.cxx
@@ -285,8 +285,26 @@ int StFwdTrackMaker::Init() {
     return kStOK;
 };
 
-EventStats StFwdTrackMaker::GetEventStats() { 
-    return mForwardTracker->getEventStats(); 
+int StFwdTrackMaker::InitRun( int runNumber ) {
+    if ( mUseBeamlineFromDB ) {
+        StFcsDb *fcsDb = dynamic_cast<StFcsDb*>(GetDataSet("fcsDb"));
+        if ( fcsDb ) {
+            mForwardTracker->setBeamline( fcsDb->getBeamlineX(),    fcsDb->getBeamlineY(),
+                                          fcsDb->getBeamlineDxDz(), fcsDb->getBeamlineDyDz() );
+            LOG_INFO << "DB beamline for run " << runNumber
+                     << ": x0=" << fcsDb->getBeamlineX()
+                     << " y0=" << fcsDb->getBeamlineY()
+                     << " dxdz=" << fcsDb->getBeamlineDxDz()
+                     << " dydz=" << fcsDb->getBeamlineDyDz() << endm;
+        } else {
+            LOG_WARN << "setUseBeamlineFromDB requested but StFcsDb not available in InitRun" << endm;
+        }
+    }
+    return kStOK;
+}
+
+EventStats StFwdTrackMaker::GetEventStats() {
+    return mForwardTracker->getEventStats();
 }
 
 /**

--- a/StRoot/StFwdTrackMaker/StFwdTrackMaker.cxx
+++ b/StRoot/StFwdTrackMaker/StFwdTrackMaker.cxx
@@ -858,6 +858,25 @@ void StFwdTrackMaker::FillEvent() {
     }
 
     // -------------------------------------------------------------------
+    // Add the BLC (beam-line-constrained) vertex, if found, so that
+    // kBLCVertexConstrained tracks below can be remapped to it.
+    int blcPvIndex = -1;
+    if ( mForwardTracker->getBLCVtxNTracks() > 0 ) {
+        StPrimaryVertex *bpv = new StPrimaryVertex();
+        TVector3 bp = mForwardTracker->getBLCVtxPos();
+        bpv->setPosition( StThreeVectorF( bp.X(), bp.Y(), bp.Z() ) );
+        float sigZ = (float)mForwardTracker->getBLCVtxSigmaZ();
+        float cov6[6] = { 0.01f, 0.f, 0.01f, 0.f, 0.f, sigZ*sigZ }; // sigmaXY=0.1cm
+        bpv->setCovariantMatrix( cov6 );
+        bpv->setNumTracksUsedInFinder( mForwardTracker->getBLCVtxNTracks() );
+        bpv->setBLCVertex();
+        stEvent->addPrimaryVertex( bpv );
+        blcPvIndex = static_cast<int>(stEvent->numberOfPrimaryVertices()) - 1;
+        LOG_DEBUG << "Added BLC vertex at z=" << bp.Z() << " sigmaZ=" << sigZ
+                  << " nTracks=" << mForwardTracker->getBLCVtxNTracks() << endm;
+    }
+
+    // -------------------------------------------------------------------
     // Add the tracks, remapping mVertexIndex to the StEvent PV collection.
     size_t indexTrack = 0;
     for ( auto &gtr : mForwardTracker->getTrackResults() ) {
@@ -868,9 +887,12 @@ void StFwdTrackMaker::FillEvent() {
             // Beamline, and PrimaryVertex-constrained tracks the relevant PV
             // is the event PV (and DCA is measured against it). For
             // ForwardVertex-constrained tracks the relevant PV is the RAVE
-            // forward vertex at offset + iVtx.
+            // forward vertex at offset + iVtx. For BLCVertex-constrained
+            // tracks the relevant PV is the BLC vertex added above.
             if ( gtr.mTrackType == StFwdTrack::kForwardVertexConstrained ) {
                 gtr.mVertexIndex = fwdRaveOffset + gtr.mVertexIndex;
+            } else if ( gtr.mTrackType == StFwdTrack::kBLCVertexConstrained && blcPvIndex >= 0 ) {
+                gtr.mVertexIndex = blcPvIndex;
             } else if ( eventPvIndex >= 0 ) {
                 gtr.mVertexIndex = eventPvIndex;
             } else {

--- a/StRoot/StFwdTrackMaker/StFwdTrackMaker.cxx
+++ b/StRoot/StFwdTrackMaker/StFwdTrackMaker.cxx
@@ -573,9 +573,33 @@ int StFwdTrackMaker::Make() {
     if ( idealNumberOfSeeds > 0 ){
         float seedFindingEff = ( mForwardTracker -> getTrackSeeds().size() + 1e-5 ) / ( idealNumberOfSeeds + 1e-5 );
         LOG_INFO << "    (vs. " << idealNumberOfSeeds << " McTracks with FST>2, eff = " << seedFindingEff << ")" << endm;
-    } 
+    }
     /**********************************************************************/
-    
+
+    /**********************************************************************/
+    // Extract FCS ECAL clusters for FCS-constrained (trkType=5) fitting
+    {
+        std::vector<ForwardTrackMaker::FcsCluster> fcsClusters;
+        StFcsCollection* fcsColl = stEvent->fcsCollection();
+        if (fcsColl && mFcsDb) {
+            for (int det = 0; det <= 1; det++) {  // ECAL north=0, south=1
+                StSPtrVecFcsCluster& cls = fcsColl->clusters(det);
+                for (size_t ic = 0; ic < cls.size(); ic++) {
+                    StFcsCluster* clu = cls[ic];
+                    if (!clu || clu->energy() <= 0) continue;
+                    StThreeVectorD xyz = mFcsDb->getStarXYZfromColumnRow(det, clu->x(), clu->y());
+                    ForwardTrackMaker::FcsCluster fc;
+                    fc.x = xyz.x(); fc.y = xyz.y(); fc.z = xyz.z();
+                    fc.e = clu->energy(); fc.det = det;
+                    fcsClusters.push_back(fc);
+                }
+            }
+        }
+        LOG_INFO << "FCS-constrained: loaded " << fcsClusters.size() << " ECAL clusters for trkType=5 fitting" << endm;
+        mForwardTracker->setFcsClusters(fcsClusters);
+    }
+    /**********************************************************************/
+
     /**********************************************************************/
     // Run Track fitting on the seeds we found
     LOG_INFO << "\tFitting FWD Track Seeds" << endm;

--- a/StRoot/StFwdTrackMaker/StFwdTrackMaker.h
+++ b/StRoot/StFwdTrackMaker/StFwdTrackMaker.h
@@ -60,6 +60,7 @@ class StFwdTrackMaker : public StMaker {
     ~StFwdTrackMaker(){/* nada */};
 
     int Init();
+    int InitRun(int runNumber);
     int Finish();
     int Make();
     void Clear(const Option_t *opts = "");
@@ -87,6 +88,7 @@ class StFwdTrackMaker : public StMaker {
 
     StFwdHitLoader mFwdHitLoader; // loads hits from StEvent or GEANT
     StFcsDb* mFcsDb = 0; // Pointer to fcs db object
+    bool mUseBeamlineFromDB = false; // if true, pass DB beamline to tracker each event
 
     // for Wavefront OBJ export
     size_t eventIndex = 0; // counts up for processed events
@@ -219,7 +221,12 @@ class StFwdTrackMaker : public StMaker {
      * @params sZ : sigma in Z (cm)
     */
     void setPrimaryVertexSigmaZ(  double sZ ) { mFwdConfig.set<double>( "TrackFitter.Vertex:sigmaZ", sZ ); }
-    // TODO: add options for beamline constraint
+    /** @brief Use measured beamline from DB for track and vertex fitting.
+     * When enabled, StFcsDb beamline parameters (x0,y0,dxdz,dydz) are passed
+     * to the tracker each run. Default false (MC uses x=y=0 line).
+    */
+    void setUseBeamlineFromDB( bool use = true ) { mUseBeamlineFromDB = use; }
+
     /** @brief Set B-field to zero (for zero field running)
      * @param zeroB : if true, use Zero B field
     */

--- a/StRoot/StFwdTrackMaker/StFwdTrackMaker.h
+++ b/StRoot/StFwdTrackMaker/StFwdTrackMaker.h
@@ -77,6 +77,14 @@ class StFwdTrackMaker : public StMaker {
   #ifndef __CINT__
     // Get the FwdTracker object
     std::shared_ptr<ForwardTracker> GetForwardTracker() { return mForwardTracker; }
+    // Same underlying tracker as GetForwardTracker(), upcast to its publicly-
+    // includable base type: ForwardTracker itself is defined inline inside
+    // StFwdTrackMaker.cxx (not in any header), so external code -- e.g.
+    // StFwdAlignmentMaker -- can't name that type directly. getTrackResults(),
+    // getTrackFitter(), and fitTrack() all live on this base class
+    // (Tracker/FwdTracker.h), which is a normal includable header. Purely
+    // additive: does not change this maker's own behavior.
+    std::shared_ptr<ForwardTrackMaker> GetForwardTrackerBase();
     EventStats GetEventStats();
     const std::vector<Seed_t> &getTrackSeeds() const;
     const std::vector<GenfitTrackResult> &getFitResults() const;

--- a/StRoot/StFwdTrackMaker/include/Tracker/FitterUtils.h
+++ b/StRoot/StFwdTrackMaker/include/Tracker/FitterUtils.h
@@ -127,11 +127,15 @@ class GenericFitSeeder : public FitSeedMaker {
         
             // const double BStrength = 0.5; // 0.5 T = 5 Gauss
             // const double C = 0.3 * BStrength; //C depends on the units used for momentum and Bfield (here GeV and Tesla)
-            const double K = 0.00029979; // K depends on the units used for Bfield and momentum (here Gauss and GeV)
+            // Fix (Issue #18): comment said "Gauss"; K is actually in units of
+            // GeV*cm/kGauss, and B=5 below is kGauss (5 kG = 0.5 T). Numerical
+            // value was already correct.
+            const double K = 0.00029979; // momentum in GeV/c, Bfield in kGauss (B=5 kG = 0.5 T)
             double pt = fabs((K*5)/qc); // pT from average measured curv
             LOG_INFO << "GenericFitSeeder::makeSeed::pt = " << pt << endm;
-            // set the momentum seed's transverse momentum
-            momSeed.SetXYZ(pt/sqrt(2.0),pt/sqrt(2.0),10);
+            // Fix (Issue #17): this line was dead code -- immediately overwritten
+            // two lines below by the proper SetXYZ call.
+            //momSeed.SetXYZ(pt/sqrt(2.0),pt/sqrt(2.0),10);
             // compute the seed's eta from seed points
             TVector3 p0 = TVector3(seed[0]->getX(), seed[0]->getY(), seed[0]->getZ());
             TVector3 p1 = TVector3(seed[1]->getX(), seed[1]->getY(), seed[1]->getZ());

--- a/StRoot/StFwdTrackMaker/include/Tracker/FitterUtils.h
+++ b/StRoot/StFwdTrackMaker/include/Tracker/FitterUtils.h
@@ -136,17 +136,21 @@ class GenericFitSeeder : public FitSeedMaker {
             // Fix (Issue #17): this line was dead code -- immediately overwritten
             // two lines below by the proper SetXYZ call.
             //momSeed.SetXYZ(pt/sqrt(2.0),pt/sqrt(2.0),10);
-            // compute the seed's eta from seed points
+            // Fix (Issue #24, 2026-06-22 seed theta fix): use disk 0 and disk 2
+            // (outermost pair) for theta/phi estimation, not disk 0/disk 1. The
+            // wider baseline gives a better eta estimate and avoids the degenerate
+            // case where disk 0 and disk 1 rasterize to the same strip center
+            // (Rxy=0 -> tan(theta)=0 -> pz blows up).
             TVector3 p0 = TVector3(seed[0]->getX(), seed[0]->getY(), seed[0]->getZ());
-            TVector3 p1 = TVector3(seed[1]->getX(), seed[1]->getY(), seed[1]->getZ());
-            double dx = (p1.X() - p0.X());
-            double dy = (p1.Y() - p0.Y());
-            double dz = (p1.Z() - p0.Z());
+            TVector3 p2 = TVector3(seed[2]->getX(), seed[2]->getY(), seed[2]->getZ());
+            double dx = (p2.X() - p0.X());
+            double dy = (p2.Y() - p0.Y());
+            double dz = (p2.Z() - p0.Z());
             double phi = TMath::ATan2(dy, dx);
             double Rxy = sqrt(dx * dx + dy * dy);
             double theta = TMath::ATan2(Rxy, dz);
             if (abs(dx) < 1e-6 || abs(dy) < 1e-6){
-                phi = TMath::ATan2( p1.Y(), p1.X() );
+                phi = TMath::ATan2( p2.Y(), p2.X() );
             }
 
             // momSeed.SetPhi(phi);

--- a/StRoot/StFwdTrackMaker/include/Tracker/FitterUtils.h
+++ b/StRoot/StFwdTrackMaker/include/Tracker/FitterUtils.h
@@ -36,6 +36,13 @@ class GenericFitSeeder : public FitSeedMaker {
     public:
         GenericFitSeeder() {}
         virtual ~GenericFitSeeder() {}
+        // Fix (Issue #25, Bug 1): sentinel returned by computeSignedCurvature() for
+        // collinear (undefined-curvature) point triples. Must be excluded in
+        // averageCurvature() -- previously that filter checked "!= -1" instead of
+        // this sentinel, so collinear triples (guaranteed for genuinely straight
+        // tracks, e.g. B=0) leaked through as a bogus near-zero curvature, blowing
+        // up the seed pT estimate (pt = K*B/curvature).
+        static constexpr double kCollinearCurvature = -1e-7;
         // Simple function to calculate the determinant of a 2x2 matrix
         inline double determinant(double a, double b, double c, double d) {
             return a * d - b * c;
@@ -63,7 +70,7 @@ class GenericFitSeeder : public FitSeedMaker {
                 LOG_DEBUG << "p1 = " << p1.x << ", " << p1.y << endm;
                 LOG_DEBUG << "p2 = " << p2.x << ", " << p2.y << endm;
                 LOG_DEBUG << "p3 = " << p3.x << ", " << p3.y << endm;
-                return -1e-7; // Curvature is undefined for collinear points
+                return kCollinearCurvature; // Curvature is undefined for collinear points
             }
 
             // Calculate the radius of the circumcircle using the formula:
@@ -100,7 +107,7 @@ class GenericFitSeeder : public FitSeedMaker {
                             // printf("Skipping non extreme points \n");
                             continue;
                         }
-                        if (curvature != -1) {  // Exclude invalid (collinear) combinations
+                        if (curvature != kCollinearCurvature) {  // Exclude invalid (collinear) combinations
                             totalCurvature += curvature;
                             ++validCombinations;
                         }
@@ -131,7 +138,15 @@ class GenericFitSeeder : public FitSeedMaker {
             // GeV*cm/kGauss, and B=5 below is kGauss (5 kG = 0.5 T). Numerical
             // value was already correct.
             const double K = 0.00029979; // momentum in GeV/c, Bfield in kGauss (B=5 kG = 0.5 T)
-            double pt = fabs((K*5)/qc); // pT from average measured curv
+            // Fix (Issue #25, Bug 2): qc == -1 means averageCurvature() found no
+            // usable (non-collinear) point triple -- e.g. too few points, or a
+            // genuinely straight track (guaranteed collinear at B=0). There is no
+            // curvature to convert to pT in that case; fall back to a high-pT
+            // (~straight-track) default instead of dividing by the sentinel, which
+            // previously produced a degenerate ~1.5 MeV seed and crashed downstream
+            // field-map lookups with a NaN assertion (StarMagField::Search).
+            bool curvatureKnown = (qc != -1.0);
+            double pt = curvatureKnown ? fabs((K*5)/qc) : 10.0; // pT from average measured curv
             LOG_INFO << "GenericFitSeeder::makeSeed::pt = " << pt << endm;
             // Fix (Issue #17): this line was dead code -- immediately overwritten
             // two lines below by the proper SetXYZ call.
@@ -155,10 +170,22 @@ class GenericFitSeeder : public FitSeedMaker {
 
             // momSeed.SetPhi(phi);
             // momSeed.SetTheta(theta);
-            momSeed.SetXYZ(pt * cos(phi), pt * sin(phi), pt / tan(theta));
-            
-            // assign charge based on sign of curvature
-            q = sgn<double>(qc);
+            // Fix (Issue #25, Bug 3): completes the seed[0]/seed[2] baseline fix
+            // above, which reduces but does not eliminate the Rxy=0 degenerate
+            // case -- a real event was found where disk0 and disk2 also land at
+            // identical (x,y), still giving tan(theta)=0. Guard the division
+            // directly instead of letting it blow up to +-inf/NaN, which
+            // previously crashed downstream field-map lookups (StarMagField::
+            // Search NaN assertion). Fall back to a fixed high-|pz|, sign-matched
+            // to the z-direction of travel.
+            double tanTheta = tan(theta);
+            double pz = (fabs(tanTheta) > 1e-6) ? (pt / tanTheta) : ((dz >= 0) ? 10.0 : -10.0);
+            momSeed.SetXYZ(pt * cos(phi), pt * sin(phi), pz);
+
+            // assign charge based on sign of curvature; default to +1 when curvature
+            // is unknown (sgn(-1) would otherwise always return -1, silently biasing
+            // every degenerate seed negative) (Issue #25, Bug 2).
+            q = curvatureKnown ? sgn<double>(qc) : 1;
         }
 };
 

--- a/StRoot/StFwdTrackMaker/include/Tracker/FwdTracker.h
+++ b/StRoot/StFwdTrackMaker/include/Tracker/FwdTracker.h
@@ -1553,12 +1553,31 @@ class ForwardTrackMaker {
         }
         if (gtr.mIsFitConverged != true)
             return 0;
+
+        // Guard: skip blown-up Kalman states. A degenerate zero-curvature fit can
+        // report sigU up to O(1e4) cm, which produces ghost hit associations far
+        // (up to ~16 cm) from the real track (Issue #2).
+        if (gtr.mMomentum.Perp() < 0.05) {
+            LOG_WARN << "addFttHits: skipping blown-up state pT=" << gtr.mMomentum.Perp() << endm;
+            return 0;
+        }
+
         if ( hitmap.find(disk) == hitmap.end() )
             return 0;
 
         Seed_t hits_near_plane;
         try {
-            auto msp = mTrackFitter->projectToFtt(disk, gtr.mTrack);
+            // Fix (Issue #1): project to disk's first front-quadrant plane, not
+            // projectToFtt(disk). That helper aliases the 0-3 disk index directly
+            // into mFttPlanes, a 32-entry per-quadrant array (see
+            // TrackFitter::createAllFttPlanes: 16 quadrants x front/back, quadrants
+            // 1-4=disk0, 5-8=disk1, 9-12=disk2, 13-16=disk3) -- indices 0-3 are
+            // actually disk-0's 4 front quadrants (all z=312.34 cm), not one entry
+            // per disk, so disks 1-3 all projected to disk 0's z. mFttPlanes[disk*4]
+            // is disk's first front quadrant -- same geometry source the real hits
+            // use (via _genfit_plane_index), just picked as a representative z for
+            // the initial projection/search.
+            auto msp = mTrackFitter->projectToPlane(mTrackFitter->mFttPlanes[disk * 4], gtr.mTrack);
 
             // now look for Ftt hits near the specified state
             // hits_near_plane = findFttHitsNearProjectedState(hitmap.at(disk), msp);
@@ -1638,13 +1657,46 @@ class ForwardTrackMaker {
             LOG_ERROR << "Invalid FST disk number: " << disk << endm;
             return 0;
         }
+
+        // Guard: skip blown-up Kalman states (Issue #2, same rationale as addFttHits).
+        if (gtr.mMomentum.Perp() < 0.05) {
+            LOG_WARN << "addFstHits: skipping blown-up state pT=" << gtr.mMomentum.Perp() << endm;
+            return 0;
+        }
+
         if ( hitmap.find(disk) == hitmap.end() )
             return 0;
 
         Seed_t nearby_hits;
         try {
-            // get measured state on plane at specified disk
-            auto msp = mTrackFitter->projectToFst(disk, gtr.mTrack);
+            // Fix (Issue #8): project to the disk's known sensor-plane z, not
+            // projectToFst(disk). That helper aliases the 0-2 disk index directly
+            // into mFstSensorPlanes, a 108-entry per-sensor array (3 disks x 12
+            // wedges x 3 sensors, see TrackFitter::createAllFstPlanes) -- indices
+            // 0-2 are actually disk-0's first wedge's 3 sensors, not one entry per
+            // disk, so disks 1-2 both projected to disk 0's z. Unlike FTT's
+            // quadrants (exactly coplanar, same physical layer), FST wedges are
+            // individually mounted, so average all 36 sensors (12 wedges x 3
+            // r-sensors) of the disk rather than trust one wedge's z alone; also
+            // use a flat z-normal plane, not any one wedge's own (azimuthally
+            // rotated) orientation, since we don't yet know which wedge/phi the
+            // track will actually cross. Geometry is fixed for the whole job, so
+            // compute the 3 disk-z averages once (lazily, on first call) instead
+            // of every track/disk/event.
+            static double fstDiskZ[3];
+            static bool fstDiskZReady = false;
+            if (!fstDiskZReady) {
+                for (int d = 0; d < 3; d++) {
+                    double z = 0;
+                    for (size_t is = d * 36; is < d * 36 + 36; is++)
+                        z += mTrackFitter->mFstSensorPlanes[is]->getO().Z();
+                    fstDiskZ[d] = z / 36.0;
+                }
+                fstDiskZReady = true;
+            }
+            auto diskPlane = genfit::SharedPlanePtr(
+                new genfit::DetPlane(TVector3(0, 0, fstDiskZ[disk]), TVector3(0, 0, 1)));
+            auto msp = mTrackFitter->projectToPlane(diskPlane, gtr.mTrack);
             // now look for Si hits near this state
             nearby_hits = findFstHitsNearProjectedState(hitmap.at(disk), msp);
         } catch (genfit::Exception &e) {
@@ -1690,8 +1742,12 @@ class ForwardTrackMaker {
             double h_phi = TMath::ATan2(h->getY(), h->getX());
             double h_r = sqrt(pow(h->getX(), 2) + pow(h->getY(), 2));
             double mdphi = fabs(h_phi - probe_phi);
-            if (mdphi > 2*3.1415926)
-                mdphi = mdphi - 2*3.1415926;
+            // Fix (Issue #9): wrapping was broken. The original check (> 2pi) never
+            // fires because fabs(atan2 diff) is already in [0, 2pi] with equality
+            // only at +-pi vs -+pi. Correct fold: if diff > pi, the short way around
+            // is 2pi - diff.
+            if (mdphi > TMath::Pi())
+                mdphi = TMath::TwoPi() - mdphi;
 
             if ( mdphi < dphi && fabs( h_r - probe_r ) < dr) { // handle 2pi edge
                 found_hits.push_back(h);
@@ -1836,8 +1892,13 @@ class ForwardTrackMaker {
                 }
             }
     
+            // Fix (Issue #3/4/7): select by minimum |dy|/|dx| (the strip's precision
+            // coordinate), not minimum dPhi. H strips measure y precisely
+            // (sigma_y~0.01 cm); their phi-center can be displaced from the track by
+            // up to ~0.18 rad since the strip spans ~4 cm in x, so gating on dPhi
+            // systematically rejected good H-strip hits (and vice versa for V/dx).
             if ( hsx > hsy ){ // horizontal strip
-                if ( sp < horizontalMin_dp ){
+                if ( sy < horizontalMin_dy ){
                     horizontalMin_dp = sp;
                     horizontalClosest = h;
                     horizontalMin_dx = sx;
@@ -1845,7 +1906,7 @@ class ForwardTrackMaker {
                     horizontalMin_dr = sr;
                 }
             } else if ( hsy > hsx ){ // vertical strip
-                if ( sp < verticalMin_dp ){
+                if ( sx < verticalMin_dx ){
                     verticalMin_dp = sp;
                     verticalClosest = h;
                     verticalMin_dx = sx;
@@ -1860,13 +1921,16 @@ class ForwardTrackMaker {
         } // loop h
 
         // check threshold and add the closest horizontal strip hit
-        if (  fabs(horizontalMin_dp) < thresholdPhi && fabs(horizontalMin_dr) < thresholdR && (horizontalMin_dx < thresholdX || horizontalMin_dy < thresholdY) ) {
+        // Fix (Issue #3/4/7): gate on the precision coordinate (|dy|) instead of
+        // dPhi, and use && instead of || so a hit isn't accepted just because one
+        // coordinate happened to pass while the other was far off (up to ~16 cm).
+        if ( horizontalMin_dy < thresholdY && fabs(horizontalMin_dr) < thresholdR ) {
             found_hits.push_back(horizontalClosest);
             LOG_INFO << "Adding horizontal strip hit with dPhi = " << horizontalMin_dp << ", dR = " << horizontalMin_dr << ", dx = " << horizontalMin_dx << ", dy = " << horizontalMin_dy << endm;
         }
-        
+
         // check threshold and add the closest vertical strip hit
-        if (  fabs(verticalMin_dp) < thresholdPhi && fabs(verticalMin_dr) < thresholdR && (verticalMin_dx < thresholdX || verticalMin_dy < thresholdY) ) {
+        if ( verticalMin_dx < thresholdX && fabs(verticalMin_dr) < thresholdR ) {
             found_hits.push_back(verticalClosest);
             LOG_INFO << "Adding vertical strip hit with dPhi = " << verticalMin_dp << ", dR = " << verticalMin_dr << ", dx = " << verticalMin_dx << ", dy = " << verticalMin_dy << endm;
         }
@@ -1894,6 +1958,12 @@ class ForwardTrackMaker {
         const FwdDataSource::HitMap_t &hitmap = mDataSource->getEpdHits();
         if (gtr.mIsFitConverged != true)
             return 0;
+
+        // Guard: skip blown-up Kalman states (Issue #2, same rationale as addFttHits).
+        if (gtr.mMomentum.Perp() < 0.05) {
+            LOG_WARN << "addEpdHits: skipping blown-up state pT=" << gtr.mMomentum.Perp() << endm;
+            return 0;
+        }
 
         Seed_t hits_near_plane;
         try {
@@ -1942,7 +2012,9 @@ class ForwardTrackMaker {
     */
     Seed_t findEpdHitsNearProjectedState(const Seed_t &available_hits,
             genfit::MeasuredStateOnPlane &msp,
-            double dx = 1.5, double dy = 1.5,
+            // Fix (Issue #11): EPD tile uncertainty is sigma_xy~4 cm, so the
+            // threshold must be >=2sigma~8cm to find real hits; widened from 1.5 cm.
+            double dx = 10.0, double dy = 10.0,
             double dr = 99, double dphi = 0.2
         ) {
 
@@ -1964,16 +2036,17 @@ class ForwardTrackMaker {
             double sx = h->getX() - msp.getPos().X();
             double sy = h->getY() - msp.getPos().Y();
 
-            if ( fabs(sr) < fabs(mindr) )
-                mindr = sr;
+            // Fix (Issue #10/12): update all 4 metrics together from the same
+            // minimum-dPhi hit. Previously each metric tracked its own independent
+            // minimum over all hits, so acceptance could mix metrics from different
+            // hits (e.g. mindx from hit A, closest=hit B) and accept the wrong hit.
             if ( fabs(sp) < fabs(mindp) ){
                 mindp = sp;
+                mindx = sx;
+                mindy = sy;
+                mindr = sr;
                 closest = h;
             }
-            if ( fabs(sx) < fabs(mindx) )
-                mindx = sx;
-            if ( fabs(sy) < fabs(mindy) )
-                mindy = sy;
 
         } // loop h
 

--- a/StRoot/StFwdTrackMaker/include/Tracker/FwdTracker.h
+++ b/StRoot/StFwdTrackMaker/include/Tracker/FwdTracker.h
@@ -499,7 +499,7 @@ class ForwardTrackMaker {
      * @param includeVertex : include the primary vertex in the fit or not
      * @return GenfitTrackResult : result of the fit
      */
-    GenfitTrackResult fitTrack(Seed_t &seed, TVector3 *momentumSeedState = nullptr) {
+    GenfitTrackResult fitTrack(Seed_t &seed, TVector3 *momentumSeedState = nullptr, int chargeSeed = 0) {
         LOG_DEBUG << "FwdTracker::fitTrack->" << endm;
         if (kProfile) mEventStats.mAttemptedFits++;
         // We will build this up as we go
@@ -512,7 +512,7 @@ class ForwardTrackMaker {
         // If we are using a provided momentum state
         if ( momentumSeedState ){
             LOG_DEBUG << "--FitTrack with provided momentum seed state" << endm;
-            mTrackFitter->fitTrack( seed, momentumSeedState );
+            mTrackFitter->fitTrack( seed, momentumSeedState, chargeSeed );
         } else {
             LOG_DEBUG << "--FitTrack without provided momentum seed state" << endm;
             mTrackFitter->fitTrack( seed );
@@ -750,8 +750,9 @@ class ForwardTrackMaker {
             Seed_t seedWithPV = gtr.mSeed;
             seedWithPV.push_back( &mEventVertexHit );
 
+            // Fix (Issue #19): also pass the global track's charge -- see setupTrack.
             TVector3 seedMomPV = gtr.mMomentum;
-            GenfitTrackResult gtrPV = fitTrack(seedWithPV, &seedMomPV);
+            GenfitTrackResult gtrPV = fitTrack(seedWithPV, &seedMomPV, gtr.mCharge);
             gtrPV.mTrackType = StFwdTrack::kPrimaryVertexConstrained;
             gtrPV.mGlobalTrackIndex = gtr.mIndex;
             gtrPV.mVertexIndex = 0;
@@ -762,11 +763,16 @@ class ForwardTrackMaker {
             } else {
                 if (kProfile) mEventStats.mFailedPrimaryFits++;
 
+                // Fix (Issue #14): set mIndex before continue -- was missing, so
+                // failed tracks got mIndex=0 and subsequent tracks had corrupted
+                // indices.
+                gtrPV.mIndex = index;
                 if (kSaveFailedFits) {
                     primaryTracks.push_back( gtrPV );
                 } else {
                     gtrPV.Clear();
                 }
+                index++;
                 continue;
             }
             // only do this for a track the converges -> that we can project
@@ -846,15 +852,19 @@ class ForwardTrackMaker {
             Seed_t seedWithPV = gtr.mSeed;
             seedWithPV.push_back( &mBeamlineHit );
 
-            GenfitTrackResult gtrPV; 
-            
-            if ( true || gtr.mIsFitConvergedFully == false ){
+            GenfitTrackResult gtrPV;
+
+            // Fix (Issue #13): "true||" made the else branch (reuse the global
+            // track's converged momentum) permanently dead -- beamline fit always
+            // re-seeded from scratch via GenericFitSeeder.
+            // Fix (Issue #19): also pass the global track's charge -- see setupTrack.
+            if ( !gtr.mIsFitConvergedFully ){
                 // if we do not provide a momentum seed state then the setup will compute one using the selected scheme
-                gtrPV = fitTrack(seedWithPV);    
+                gtrPV = fitTrack(seedWithPV);
             } else {
-                // Only use the momentum of the global track if it converged
+                // Only use the momentum/charge of the global track if it converged
                 TVector3 seedMomBL = gtr.mMomentum;
-                gtrPV = fitTrack(seedWithPV, &seedMomBL);
+                gtrPV = fitTrack(seedWithPV, &seedMomBL, gtr.mCharge);
             }
 
             gtrPV.mTrackType = StFwdTrack::kBeamlineConstrained;
@@ -868,11 +878,16 @@ class ForwardTrackMaker {
                 LOG_DEBUG << "\tInitial Beamline fitting failed for seed " << index << endm;
                 if (kProfile) mEventStats.mFailedBeamlineFits++;
 
+                // Fix (Issue #14): set mIndex before continue -- was missing, so
+                // failed tracks got mIndex=0 and subsequent tracks had corrupted
+                // indices.
+                gtrPV.mIndex = index;
                 if (kSaveFailedFits) {
                     beamlineTracks.push_back( gtrPV );
                 } else {
                     gtrPV.Clear();
                 }
+                index++;
                 continue;
             }
             gtrPV.setDCA( mEventVertex );
@@ -987,12 +1002,17 @@ class ForwardTrackMaker {
                 Seed_t seedWithVtx = gtr->mSeed;
                 seedWithVtx.push_back( &mFwdVerticesAsHits.back() );
                 TVector3 seedMom = gtr->mMomentum;
-                GenfitTrackResult gtrPV = fitTrack(seedWithVtx, &seedMom);
+                // Fix (Issue #19): also pass the global track's charge -- see setupTrack.
+                GenfitTrackResult gtrPV = fitTrack(seedWithVtx, &seedMom, gtr->mCharge);
                 if ( gtrPV.mIsFitConvergedFully ) {
                     if (kProfile) mEventStats.mGoodSecondaryFits++;
                 } else {
                     if (kProfile) mEventStats.mFailedSecondaryFits++;
+                    // Fix (Issue #14): set mIndex before continue -- same missing
+                    // index++ as the beamline/primary fitters.
+                    gtrPV.mIndex = index;
                     gtrPV.Clear();
+                    index++;
                     continue;
                 }
                 gtrPV.setDCA( TVector3( vtx->getPos().X(), vtx->getPos().Y(), vtx->getPos().Z() ) );

--- a/StRoot/StFwdTrackMaker/include/Tracker/FwdTracker.h
+++ b/StRoot/StFwdTrackMaker/include/Tracker/FwdTracker.h
@@ -608,7 +608,21 @@ class ForwardTrackMaker {
             }
         }
 
+        // Normal FST+FTT refit with full phi sigma (stable convergence)
         auto gtrGlobalRefit = fitTrack( gtrGlobal.mSeed, &gtrGlobal.mMomentum );
+
+        // Fix (Issue #24): warm-sigma refinement. If the refit converged, run a
+        // second pass with tight FST r+phi sigma (pitch/sqrt12 for both).
+        // warmFitFstTightSigma modifies mFitTrack in-place; refreshFromTrack()
+        // picks up the updated momentum, charge, covariance, and chi2. Applies to
+        // all five track types (Global/BLC/Primary/FwdVtx/BLCVtx) -- no
+        // track-type guard here.
+        if ( gtrGlobalRefit.mIsFitConvergedFully ){
+            bool warmOk = mTrackFitter->warmFitFstTightSigma( gtrGlobal.mSeed );
+            if ( warmOk )
+                gtrGlobalRefit.refreshFromTrack();
+        }
+
         gtrGlobalRefit.setDCA( mEventVertex );
 
         return gtrGlobalRefit;
@@ -1086,7 +1100,7 @@ class ForwardTrackMaker {
      */
     void doTrackFitting( const std::vector<Seed_t> &trackSeeds) {
         LOG_DEBUG << ">>doTrackFitting" << endm;
-        
+
         long long itStart = FwdTrackerUtils::nowNanoSecond();
 
         std::vector<GenfitTrackResult> globalTracks;

--- a/StRoot/StFwdTrackMaker/include/Tracker/FwdTracker.h
+++ b/StRoot/StFwdTrackMaker/include/Tracker/FwdTracker.h
@@ -58,6 +58,10 @@ class ForwardTrackMaker {
     const std::vector<genfit::GFRaveVertex*> &getVertices() const { return mFwdVertices; }
     const EventStats &getEventStats() const { return mEventStats; }
 
+    TVector3 getBLCVtxPos()     const { return mBLCVtxPos; }
+    double   getBLCVtxSigmaZ()  const { return sqrt(std::max(0.0, (double)mBLCVtxHit._covmat(2,2))); }
+    int      getBLCVtxNTracks() const { return mBLCVtxNTracks; }
+
     void Clear(){
         for ( auto &gtr : mTrackResults ){
             gtr.Clear();
@@ -976,6 +980,154 @@ class ForwardTrackMaker {
         return beamlineTracks;
     }
 
+    // Fit BLC-derived forward vertex and refit BLC tracks constrained to that vertex point.
+    //
+    // Algorithm:
+    //   1. Select good BLC tracks; extract DCA-z (mDCA.Z()) as z-estimate.
+    //   2. Weighted mean z_vtx with w_i = nFitPoints; scatter-based sigma_vtx.
+    //   3. Iterative outlier rejection: remove |z_i - z_vtx| > N*sigma.
+    //   4. Build FwdHit at (x_BL, y_BL, z_vtx) with sigma_xy from beam spot,
+    //      sigma_z from vertex fit scatter.
+    //   5. Refit each BLC track with that hit appended to its seed.
+    std::vector<GenfitTrackResult> doBLCVertexFitting( std::vector<GenfitTrackResult> &beamlineTracks ) {
+        if (verbose) LOG_INFO << ">>doBLCVertexFitting( #blc = " << beamlineTracks.size() << " )" << endm;
+        long long itStart = FwdTrackerUtils::nowNanoSecond();
+        mBLCVtxNTracks = 0; // reset per-event
+
+        std::vector<GenfitTrackResult> blcVtxTracks;
+
+        // --- Config ---
+        const int    minNFit    = mConfig.get<int>   ("TrackFitter:blcVtxMinNFitHits",  4);
+        const double maxChi2Ndf = mConfig.get<double>("TrackFitter:blcVtxMaxChi2Ndf",  10.0);
+        const double looseDcaZ  = mConfig.get<double>("TrackFitter:blcVtxLooseDcaZ",  100.0);
+        const double maxDcaXY   = mConfig.get<double>("TrackFitter:blcVtxMaxDcaXY",    10.0); // rejects sentinel (99,99,99) from failed extrapolateToLine; valid BLC tracks have DCA-XY~0
+        const double outlierN   = mConfig.get<double>("TrackFitter:blcVtxOutlierNSigma", 3.0);
+        const double sigmaXY    = mConfig.get<double>("TrackFitter:blcVtxSigmaXY",       0.1);
+        const double sigmaZsingle = mConfig.get<double>("TrackFitter:blcVtxSigmaZSingle", 30.0); // loose z when only 1 track
+
+        // --- Step 1: collect good BLC tracks for vertex input ---
+        struct TrkZ { double z; double w; };
+        std::vector<TrkZ> trkZs;
+        for (auto &gtr : beamlineTracks) {
+            if (!gtr.mIsFitConvergedFully) continue;
+            if (gtr.mNumFitPoints < minNFit) continue;
+            if (gtr.mNdf > 0 && gtr.mChi2 / gtr.mNdf > maxChi2Ndf) continue;
+            double dcaXY = sqrt(gtr.mDCA.X()*gtr.mDCA.X() + gtr.mDCA.Y()*gtr.mDCA.Y());
+            if (dcaXY > maxDcaXY) continue; // rejects sentinel (99,99,99); valid BLC tracks have DCA-XY~0
+            double zi = gtr.mDCA.Z();
+            if (fabs(zi) > looseDcaZ) continue;
+            trkZs.push_back({zi, (double)gtr.mNumFitPoints}); // weight = nFitPoints
+        }
+
+        // --- Steps 2-3: weighted mean + outlier rejection ---
+        double z_vtx    = mBeamlineHit.getZ(); // fallback = beam hit z (0)
+        double sigma_vtx = sigmaZsingle;        // fallback for single-track or 0-track events
+
+        if (!trkZs.empty()) {
+            for (int iter = 0; iter < 3; iter++) {
+                double sumW = 0, sumWZ = 0;
+                for (auto &tz : trkZs) { sumW += tz.w; sumWZ += tz.w * tz.z; }
+                if (sumW <= 0) break;
+                z_vtx = sumWZ / sumW;
+
+                if (trkZs.size() >= 2) {
+                    double sumWdz2 = 0;
+                    for (auto &tz : trkZs) sumWdz2 += tz.w * (tz.z - z_vtx) * (tz.z - z_vtx);
+                    // weighted RMS; floor at 1 cm to avoid over-constraint
+                    sigma_vtx = std::max(1.0, sqrt(sumWdz2 / (((double)trkZs.size()-1.0) * sumW / trkZs.size())));
+                }
+
+                bool removed = false;
+                for (auto it = trkZs.begin(); it != trkZs.end(); ) {
+                    if (fabs(it->z - z_vtx) > outlierN * sigma_vtx) {
+                        it = trkZs.erase(it); removed = true;
+                    } else { ++it; }
+                }
+                if (!removed) break;
+            }
+        }
+
+        if (verbose || kProfile)
+            LOG_INFO << "BLCVertex: z_vtx=" << z_vtx << " cm  sigma_vtx=" << sigma_vtx
+                     << " cm  nTrkUsed=" << trkZs.size() << "/" << beamlineTracks.size() << endm;
+
+        // --- Step 4: build the vertex hit ---
+        // Apply slope correction: beamline position at the fitted vertex z
+        double x_BL = mBeamlineHit.getX() + mBeamlineDxDz * z_vtx;
+        double y_BL = mBeamlineHit.getY() + mBeamlineDyDz * z_vtx;
+        mBLCVtxPos.SetXYZ(x_BL, y_BL, z_vtx);
+        mBLCVtxHit.setXYZDetId(x_BL, y_BL, z_vtx, kTpcId);
+        mBLCVtxHit._covmat.Zero();
+        mBLCVtxHit._covmat(0, 0) = sigmaXY * sigmaXY;
+        mBLCVtxHit._covmat(1, 1) = sigmaXY * sigmaXY;
+        mBLCVtxHit._covmat(2, 2) = sigma_vtx * sigma_vtx;
+        mBLCVtxNTracks = (int)trkZs.size();
+
+        // --- Step 5: refit each BLC track with the vertex hit ---
+        size_t index = 0;
+        for (auto &gtr : beamlineTracks) {
+            if (kProfile) mEventStats.mAttemptedBLCVtxFits++;
+
+            Seed_t seedWithVtx = gtr.mSeed;
+            seedWithVtx.push_back(&mBLCVtxHit);
+
+            GenfitTrackResult gtrV;
+            if (!gtr.mIsFitConvergedFully) {
+                gtrV = fitTrack(seedWithVtx);
+            } else {
+                gtrV = fitTrack(seedWithVtx, &gtr.mMomentum, gtr.mCharge);
+            }
+            gtrV.mTrackType        = StFwdTrack::kBLCVertexConstrained;
+            gtrV.mGlobalTrackIndex = gtr.mGlobalTrackIndex;
+            gtrV.mVertexIndex      = 0;
+
+            if (!gtrV.mIsFitConvergedFully) {
+                if (kProfile) mEventStats.mFailedBLCVtxFits++;
+                gtrV.mIndex = index;
+                if (kSaveFailedFits) blcVtxTracks.push_back(gtrV);
+                else gtrV.Clear();
+                index++;
+                continue;
+            }
+            if (kProfile) mEventStats.mGoodBLCVtxFits++;
+            gtrV.setDCA(mBLCVtxPos); // extrapolates to vertex point (see GenfitTrackResult::setDCA)
+
+            // refit with additional hits
+            GenfitTrackResult gtrVRefit = refitTrack(gtrV, mBLCVtxPos);
+            gtrVRefit.mIndex           = index;
+            gtrVRefit.mTrackType       = StFwdTrack::kBLCVertexConstrained;
+            gtrVRefit.mGlobalTrackIndex = gtr.mGlobalTrackIndex;
+            gtrVRefit.mVertexIndex      = 0;
+
+            if (gtrVRefit.mIsFitConvergedFully) {
+                blcVtxTracks.push_back(gtrVRefit);
+                gtrV.Clear();
+                if (kProfile) mEventStats.mGoodBLCVtxRefits++;
+            } else {
+                blcVtxTracks.push_back(gtrV);
+                gtrVRefit.Clear();
+                if (kProfile) mEventStats.mFailedBLCVtxRefits++;
+            }
+            index++;
+        }
+
+        long long duration = (FwdTrackerUtils::nowNanoSecond() - itStart) * 1e-6;
+        if (kProfile) mEventStats.mBLCVtxFitDuration.push_back((float)duration);
+
+        if (verbose > 0 && kProfile) {
+            LOG_INFO << "\tBLCVertex Track Fitting Results"
+                     << Form(" (took %lld ms): Attempts=%d Good=%d Failed=%d GoodRefit=%d FailedRefit=%d",
+                             duration,
+                             mEventStats.mAttemptedBLCVtxFits,
+                             mEventStats.mGoodBLCVtxFits,
+                             mEventStats.mFailedBLCVtxFits,
+                             mEventStats.mGoodBLCVtxRefits,
+                             mEventStats.mFailedBLCVtxRefits) << endm;
+        }
+
+        return blcVtxTracks;
+    }
+
     std::vector<GenfitTrackResult> doSecondaryTrackFitting( const std::vector<GenfitTrackResult> &globalTracks) {
         mFwdVerticesAsHits.clear();
         if (verbose){
@@ -1130,6 +1282,7 @@ class ForwardTrackMaker {
         std::vector<GenfitTrackResult> globalTracks;
         std::vector<GenfitTrackResult> primaryTracks;
         std::vector<GenfitTrackResult> beamlineTracks;
+        std::vector<GenfitTrackResult> blcVtxTracks;
         std::vector<GenfitTrackResult> secondaryTracks;
 
         // Should we try to refit the track with aadditional points from other detectors?
@@ -1194,6 +1347,16 @@ class ForwardTrackMaker {
         // End Step 3
         /***********************************************************************************************************/
 
+        /***********************************************************************************************************/
+        // Step 3.5: BLC-Vertex fitting — fit z_vtx from BLC DCA-z, refit tracks to that point
+        const bool do_blcvtx_fitting = mConfig.get<bool>("TrackFitter:doBLCVertexFitting", true);
+        if (do_blcvtx_fitting && do_beamline_fitting) {
+            blcVtxTracks = doBLCVertexFitting(beamlineTracks);
+        } else {
+            LOG_INFO << "Event configuration is skipping BLC vertex fitting" << endm;
+        }
+        // End Step 3.5
+        /***********************************************************************************************************/
 
         const bool do_fwd_primary_fitting = mConfig.get<bool>("TrackFitter:doPrimaryTrackFitting", true);;
         /***********************************************************************************************************/
@@ -1222,6 +1385,7 @@ class ForwardTrackMaker {
         mTrackResults.insert( mTrackResults.end(), globalTracks.begin(), globalTracks.end() );
         mTrackResults.insert( mTrackResults.end(), primaryTracks.begin(), primaryTracks.end() );
         mTrackResults.insert( mTrackResults.end(), beamlineTracks.begin(), beamlineTracks.end() );
+        mTrackResults.insert( mTrackResults.end(), blcVtxTracks.begin(), blcVtxTracks.end() );
         mTrackResults.insert( mTrackResults.end(), secondaryTracks.begin(), secondaryTracks.end() );
         LOG_DEBUG << "Copied globals, beamline, primary, and secondary. Now mTrackResults.size() = " << mTrackResults.size() << endm;
 
@@ -2164,6 +2328,10 @@ class ForwardTrackMaker {
     FwdHit mBeamlineHit;
     double mBeamlineDxDz = 0.0; // dx/dz slope from DB (0 = MC default)
     double mBeamlineDyDz = 0.0; // dy/dz slope from DB (0 = MC default)
+    // BLCVertex — hit and position for the beam-line-constrained vertex fit
+    FwdHit  mBLCVtxHit;
+    TVector3 mBLCVtxPos;
+    int      mBLCVtxNTracks = 0;
     vector<FwdHit> mFwdVerticesAsHits;
     genfit::GFRaveVertexFactory mGFRVertexFactory;
 

--- a/StRoot/StFwdTrackMaker/include/Tracker/FwdTracker.h
+++ b/StRoot/StFwdTrackMaker/include/Tracker/FwdTracker.h
@@ -1128,6 +1128,147 @@ class ForwardTrackMaker {
         return blcVtxTracks;
     }
 
+    // FCS ECAL cluster data for FCS-constrained fitting (set per event from StFwdTrackMaker)
+    struct FcsCluster { double x, y, z, e; int det; };
+    std::vector<FcsCluster> mFcsClusters;
+    std::vector<FwdHit>     mFcsHits; // per-track FCS hits, kept alive until FillEvent
+
+    void setFcsClusters(const std::vector<FcsCluster>& clusters) { mFcsClusters = clusters; }
+
+    // Step 3.6: refit each BLCVtx track with the matched FCS ECAL cluster (trkType=5)
+    std::vector<GenfitTrackResult> doFCSConstrainedFitting(std::vector<GenfitTrackResult>& blcVtxTracks) {
+        if (verbose) LOG_INFO << ">>doFCSConstrainedFitting( #blcVtx=" << blcVtxTracks.size() << " )" << endm;
+
+        std::vector<GenfitTrackResult> fcsTracks;
+        if (mFcsClusters.empty()) {
+            LOG_INFO << "FCS-constrained: no ECAL clusters this event, skipping" << endm;
+            return fcsTracks;
+        }
+
+        const double matchDr  = mConfig.get<double>("TrackFitter:fcsMatchDr",   5.0);
+        const double matchEoP = mConfig.get<double>("TrackFitter:fcsMatchEoP",  0.0); // 0=off; >0 require |E/p-1|<matchEoP
+        const double sigmaPos = mConfig.get<double>("TrackFitter:fcsSigmaPos",  1.2 );
+        const double sigmaZ   = mConfig.get<double>("TrackFitter:fcsSigmaZ",   10.0 );
+        const double zPlane   = mConfig.get<double>("TrackFitter:fcsZPlane",  725.0 );
+
+        auto fcsPlane = std::make_shared<genfit::DetPlane>(
+            TVector3(0, 0, zPlane), TVector3(0, 0, 1) );
+        // Intermediate plane at z=500 cm: past the solenoid return yoke (~z=350 cm),
+        // fringe field is ~10-20% of peak. Used as fallback when full extrapolation fails.
+        const double zMid = mConfig.get<double>("TrackFitter:fcsZMid", 500.0);
+        auto fcsMidPlane = std::make_shared<genfit::DetPlane>(
+            TVector3(0, 0, zMid), TVector3(0, 0, 1) );
+
+        mFcsHits.clear();
+        mFcsHits.reserve(blcVtxTracks.size());
+
+        int nLooper = 0, nFallback = 0, nNoCluster = 0;
+
+        size_t index = 0;
+        for (auto& gtrBLC : blcVtxTracks) {
+            if (!gtrBLC.mIsFitConvergedFully) { index++; continue; }
+
+            // Project BLCVtx track to ECAL shower-max plane.
+            // Low-pT tracks loop in the STAR field and fail projectToPlane with a genfit::Exception.
+            // Fallback: project to z=500 cm (fringe field region), then straight-line to z=725 cm.
+            TVector3 posAtFCS;
+            double dynMatchDr = matchDr;
+            bool usedFallback = false;
+            try {
+                auto msp = mTrackFitter->projectToPlane(fcsPlane, gtrBLC.mTrack);
+                posAtFCS = msp.getPos();
+                // Dynamic matching window from Genfit covariance propagated to FCS plane.
+                // State: (q/p, u', v', u, v) — cov(3,3)=σ_u², cov(4,4)=σ_v² (position on plane, cm²).
+                const auto& cov = msp.getCov();
+                double sigSq = std::max(0.0, (double)cov(3,3))
+                             + std::max(0.0, (double)cov(4,4))
+                             + sigmaPos * sigmaPos;
+                dynMatchDr = 4.0 * sqrt(sigSq);
+                dynMatchDr = std::max(dynMatchDr,  5.0);
+                dynMatchDr = std::min(dynMatchDr, 50.0);
+            } catch (genfit::Exception&) {
+                nLooper++;
+                // Fallback: project to z=500 cm, then straight-line to z=725 cm.
+                // Tracks that fail at z=725 cm but succeed at z=500 cm are borderline loopers
+                // that exit the solenoid region; the remaining ~225 cm has weak fringe field.
+                try {
+                    auto msp5 = mTrackFitter->projectToPlane(fcsMidPlane, gtrBLC.mTrack);
+                    TVector3 pos5 = msp5.getPos();
+                    TVector3 mom5 = msp5.getMom();
+                    if (fabs(mom5.Z()) < 1e-6) { index++; continue; }  // sanity: backward-going
+                    double dz = zPlane - pos5.Z();
+                    posAtFCS.SetXYZ(pos5.X() + mom5.X() * dz / mom5.Z(),
+                                    pos5.Y() + mom5.Y() * dz / mom5.Z(),
+                                    zPlane);
+                    // Straight-line ignores fringe field over ~225 cm → larger window than RK gives.
+                    dynMatchDr = 20.0;
+                    usedFallback = true;
+                    nFallback++;
+                } catch (genfit::Exception&) {
+                    index++; continue;  // true looper, can't reach z=500 cm either
+                }
+            }
+
+            // Find closest ECAL cluster on same side passing dr and optional E/p cuts
+            double pMag = gtrBLC.mMomentum.Mag();
+            double bestDr = dynMatchDr;
+            int bestIc = -1;
+            for (int ic = 0; ic < (int)mFcsClusters.size(); ic++) {
+                const auto& cl = mFcsClusters[ic];
+                if (posAtFCS.X() * cl.x <= 0) continue;  // same North/South side
+                double dx = posAtFCS.X() - cl.x, dy = posAtFCS.Y() - cl.y;
+                double dr = sqrt(dx*dx + dy*dy);
+                if (dr >= bestDr) continue;
+                if (matchEoP > 0 && pMag > 0 && fabs(cl.e/pMag - 1.0) > matchEoP) continue;
+                bestDr = dr; bestIc = ic;
+            }
+
+            if (bestIc < 0) { nNoCluster++; index++; continue; }
+            const auto& cl = mFcsClusters[bestIc];
+            LOG_INFO << "FCS-constrained: trk " << index << " matched ECAL cluster at ("
+                      << cl.x << "," << cl.y << "," << cl.z << ") E=" << cl.e
+                      << " dr=" << bestDr << " E/p=" << (pMag>0?cl.e/pMag:0) << endm;
+
+            // Build FwdHit for ECAL cluster (kTpcId → 3D spacepoint, like vertex hits)
+            mFcsHits.push_back(FwdHit());
+            FwdHit& fcsHit = mFcsHits.back();
+            fcsHit.setXYZDetId(cl.x, cl.y, cl.z, kTpcId);
+            fcsHit._covmat.Zero();
+            fcsHit._covmat(0, 0) = sigmaPos * sigmaPos;
+            fcsHit._covmat(1, 1) = sigmaPos * sigmaPos;
+            fcsHit._covmat(2, 2) = sigmaZ   * sigmaZ;
+
+            Seed_t seedWithFCS = gtrBLC.mSeed;
+            seedWithFCS.push_back(&fcsHit);
+
+            GenfitTrackResult gtrFCS;
+            if (gtrBLC.mIsFitConvergedFully)
+                gtrFCS = fitTrack(seedWithFCS, &gtrBLC.mMomentum, gtrBLC.mCharge);
+            else
+                gtrFCS = fitTrack(seedWithFCS);
+
+            gtrFCS.mTrackType        = StFwdTrack::kFCSConstrained;
+            gtrFCS.mGlobalTrackIndex = gtrBLC.mGlobalTrackIndex;
+            gtrFCS.mVertexIndex      = 0;
+            gtrFCS.mIndex            = index;
+
+            if (gtrFCS.mIsFitConvergedFully) {
+                gtrFCS.setDCA(mBLCVtxPos);
+                fcsTracks.push_back(std::move(gtrFCS));
+            } else {
+                gtrFCS.Clear();
+            }
+            index++;
+        }
+
+        LOG_INFO << "FCS-constrained: " << fcsTracks.size() << " FCS-constrained tracks from "
+                 << blcVtxTracks.size() << " BLCVtx tracks"
+                 << " | looper(to725)=" << nLooper
+                 << " fallback(via500)=" << nFallback
+                 << " no_cluster=" << nNoCluster << endm;
+        return fcsTracks;
+    } // doFCSConstrainedFitting
+
     std::vector<GenfitTrackResult> doSecondaryTrackFitting( const std::vector<GenfitTrackResult> &globalTracks) {
         mFwdVerticesAsHits.clear();
         if (verbose){
@@ -1283,6 +1424,7 @@ class ForwardTrackMaker {
         std::vector<GenfitTrackResult> primaryTracks;
         std::vector<GenfitTrackResult> beamlineTracks;
         std::vector<GenfitTrackResult> blcVtxTracks;
+        std::vector<GenfitTrackResult> fcsConstrainedTracks;
         std::vector<GenfitTrackResult> secondaryTracks;
 
         // Should we try to refit the track with aadditional points from other detectors?
@@ -1358,6 +1500,17 @@ class ForwardTrackMaker {
         // End Step 3.5
         /***********************************************************************************************************/
 
+        /***********************************************************************************************************/
+        // Step 3.6: FCS-Constrained fitting — refit BLCVtx tracks with matched ECAL cluster (trkType=5)
+        const bool do_fcs_fitting = mConfig.get<bool>("TrackFitter:doFCSConstrainedFitting", true);
+        if (do_fcs_fitting && do_blcvtx_fitting && !mFcsClusters.empty()) {
+            fcsConstrainedTracks = doFCSConstrainedFitting(blcVtxTracks);
+        } else {
+            LOG_INFO << "Event configuration is skipping FCS-constrained fitting" << endm;
+        }
+        // End Step 3.6
+        /***********************************************************************************************************/
+
         const bool do_fwd_primary_fitting = mConfig.get<bool>("TrackFitter:doPrimaryTrackFitting", true);;
         /***********************************************************************************************************/
         // Step 4: Refit the track with the primary vertex
@@ -1386,6 +1539,7 @@ class ForwardTrackMaker {
         mTrackResults.insert( mTrackResults.end(), primaryTracks.begin(), primaryTracks.end() );
         mTrackResults.insert( mTrackResults.end(), beamlineTracks.begin(), beamlineTracks.end() );
         mTrackResults.insert( mTrackResults.end(), blcVtxTracks.begin(), blcVtxTracks.end() );
+        mTrackResults.insert( mTrackResults.end(), fcsConstrainedTracks.begin(), fcsConstrainedTracks.end() );
         mTrackResults.insert( mTrackResults.end(), secondaryTracks.begin(), secondaryTracks.end() );
         LOG_DEBUG << "Copied globals, beamline, primary, and secondary. Now mTrackResults.size() = " << mTrackResults.size() << endm;
 

--- a/StRoot/StFwdTrackMaker/include/Tracker/FwdTracker.h
+++ b/StRoot/StFwdTrackMaker/include/Tracker/FwdTracker.h
@@ -563,7 +563,14 @@ class ForwardTrackMaker {
         return gtr;
     } // fitTrack
 
-    GenfitTrackResult refitTrack( GenfitTrackResult gtrGlobal ) {
+    // Fix (Issue #27): refitTrack() used to build a fresh GenfitTrackResult via
+    // fitTrack(), which never sets mTrackType (defaults to kGlobal=0), then
+    // unconditionally called setDCA(mEventVertex) -- regardless of the caller's
+    // real track type or intended vertex. Now takes an explicit dcaTarget
+    // argument and propagates the caller's mTrackType onto the refit result
+    // before calling setDCA(), so the correct point-vs-line extrapolation method
+    // and target are used for every track type.
+    GenfitTrackResult refitTrack( GenfitTrackResult gtrGlobal, TVector3 dcaTarget ) {
         LOG_DEBUG << "FwdTracker::refitTrack->" << endm;
         const bool doRefit = mConfig.get<bool>("TrackFitter:refit", false);
         if ( !doRefit ){
@@ -623,7 +630,8 @@ class ForwardTrackMaker {
                 gtrGlobalRefit.refreshFromTrack();
         }
 
-        gtrGlobalRefit.setDCA( mEventVertex );
+        gtrGlobalRefit.mTrackType = gtrGlobal.mTrackType;
+        gtrGlobalRefit.setDCA( dcaTarget );
 
         return gtrGlobalRefit;
     }
@@ -691,7 +699,7 @@ class ForwardTrackMaker {
             // Look for additional hits in the other tracking detector
             // and add the new hits to the track
 
-            GenfitTrackResult gtrGlobalRefit = refitTrack( gtrGlobal );
+            GenfitTrackResult gtrGlobalRefit = refitTrack( gtrGlobal, mEventVertex );
             gtrGlobalRefit.mIndex = index;
             gtrGlobalRefit.mTrackType = StFwdTrack::kGlobal;
             // End Step 2
@@ -791,10 +799,10 @@ class ForwardTrackMaker {
             }
             // only do this for a track the converges -> that we can project
             gtrPV.setDCA( mEventVertex );
-            
+
             LOG_INFO << "\tInitial fit complete, now refitting with additional points" << endm;
             // refit the track with additional points
-            GenfitTrackResult gtrPVRefit = refitTrack( gtrPV );
+            GenfitTrackResult gtrPVRefit = refitTrack( gtrPV, mEventVertex );
             gtrPVRefit.mIndex = index;
             gtrPVRefit.mTrackType = StFwdTrack::kPrimaryVertexConstrained;
             gtrPVRefit.mGlobalTrackIndex = gtr.mIndex;
@@ -905,11 +913,10 @@ class ForwardTrackMaker {
                 continue;
             }
             gtrPV.setDCA( mEventVertex );
-            
 
             LOG_INFO << "\tInitial Beamline fit completed, now refitting with additional hits" << endm;
             // refit the track with additional points
-            GenfitTrackResult gtrPVRefit = refitTrack( gtrPV );
+            GenfitTrackResult gtrPVRefit = refitTrack( gtrPV, mEventVertex );
             gtrPVRefit.mIndex = index;
             gtrPVRefit.mTrackType = StFwdTrack::kBeamlineConstrained;
             gtrPVRefit.mGlobalTrackIndex = gtr.mIndex;
@@ -1029,14 +1036,22 @@ class ForwardTrackMaker {
                     index++;
                     continue;
                 }
-                gtrPV.setDCA( TVector3( vtx->getPos().X(), vtx->getPos().Y(), vtx->getPos().Z() ) );
+                // Fix (Issue #27): set mTrackType before setDCA() -- previously
+                // setDCA() ran first, so even the initial DCA used line- not
+                // point-extrapolation (mTrackType still defaulted to kGlobal).
+                // Also save the found forward vertex position and pass it through
+                // to refitTrack() explicitly -- previously refitTrack() always
+                // used mEventVertex internally, silently changing the DCA target
+                // from the found forward vertex to the wrong vertex after refit.
+                TVector3 fwdVtxPos( vtx->getPos().X(), vtx->getPos().Y(), vtx->getPos().Z() );
                 gtrPV.mTrackType = StFwdTrack::kForwardVertexConstrained;
+                gtrPV.setDCA( fwdVtxPos );
                 gtrPV.mGlobalTrackIndex = gtr->mIndex;
                 gtrPV.mVertexIndex = iVtx;
 
                 LOG_INFO << "\tInitial fit complete, now refitting with additional points" << endm;
                 // refit the track with additional points
-                GenfitTrackResult gtrPVRefit = refitTrack( gtrPV );
+                GenfitTrackResult gtrPVRefit = refitTrack( gtrPV, fwdVtxPos );
                 gtrPVRefit.mIndex = index;
                 gtrPVRefit.mTrackType = StFwdTrack::kForwardVertexConstrained;
                 gtrPVRefit.mGlobalTrackIndex = gtr->mIndex;

--- a/StRoot/StFwdTrackMaker/include/Tracker/FwdTracker.h
+++ b/StRoot/StFwdTrackMaker/include/Tracker/FwdTracker.h
@@ -107,6 +107,15 @@ class ForwardTrackMaker {
         mBeamlineHit._covmat(2,2) = 100*100;
     } //initialize
 
+    // Set measured beamline from DB (call each event from StFwdTrackMaker::Make).
+    // x0,y0 = beamline position at z=0 [cm]; dxdz,dydz = slopes.
+    // Default (0,0,0,0) matches MC convention and leaves covariance unchanged.
+    void setBeamline(double x0, double y0, double dxdz, double dydz) {
+        mBeamlineHit.setXYZDetId( (float)x0, (float)y0, 0, kTpcId );
+        mBeamlineDxDz = dxdz;
+        mBeamlineDyDz = dydz;
+    }
+
     /**
      * @brief Loads Criteria from XML configuration.
      * Utility function for loading criteria from XML config.
@@ -2153,6 +2162,8 @@ class ForwardTrackMaker {
     TVector3 mEventVertex;
     FwdHit mEventVertexHit;
     FwdHit mBeamlineHit;
+    double mBeamlineDxDz = 0.0; // dx/dz slope from DB (0 = MC default)
+    double mBeamlineDyDz = 0.0; // dy/dz slope from DB (0 = MC default)
     vector<FwdHit> mFwdVerticesAsHits;
     genfit::GFRaveVertexFactory mGFRVertexFactory;
 

--- a/StRoot/StFwdTrackMaker/include/Tracker/GenfitTrackResult.h
+++ b/StRoot/StFwdTrackMaker/include/Tracker/GenfitTrackResult.h
@@ -6,6 +6,7 @@
 #include "GenFit/FitStatus.h"
 #include <map>
 #include <unordered_map>
+#include "StEvent/StFwdTrack.h"
 
 // Utility class for evaluating ID and QA truth
 struct MCTruthUtils {
@@ -28,10 +29,18 @@ struct MCTruthUtils {
         using P = decltype(truth)::value_type;
         auto dom = max_element(begin(truth), end(truth), [](P a, P b){ return a.second < b.second; });
 
-        // QA represents the percentage of hits which
-        // vote the same way on the track
-        if ( hits.size() > 0 )
-            qa = double(dom->second) / double(hits.size()) ;
+        // QA represents the percentage of hits which vote the same way on the track.
+        // Fix (Issue #15): original used hits.size() as denominator, which includes
+        // PV/beamline hits that are skipped (isPV) in the numerator -- making qa < 1
+        // even for a pure single-track seed, and making qa=1.0 impossible when a
+        // vertex constraint is in the seed. Use the count of non-PV hits instead.
+        int nonPVHits = 0;
+        for ( auto hit : hits ) {
+            FwdHit* fh = dynamic_cast<FwdHit*>(hit);
+            if ( fh && !fh->isPV() ) nonPVHits++;
+        }
+        if ( nonPVHits > 0 )
+            qa = double(dom->second) / double(nonPVHits);
         else
             qa = 0;
 
@@ -246,9 +255,14 @@ public:
         if ( mTrack ){
             try {
                 auto dcaState = mTrack->getFittedState( 0 );
-                // this->mTrackRep->extrapolateToPoint( dcaState, mPV );
+                // Fix (Issue #16): PV-constrained tracks benefit from full 3D DCA
+                // (extrapolateToPoint) instead of transverse-only extrapolateToLine.
                 TVector3 beamDirection = TVector3(0,0,1);
-                mTrack->getCardinalRep()->extrapolateToLine( dcaState, mPV, beamDirection );
+                if ( mTrackType == StFwdTrack::kPrimaryVertexConstrained ) {
+                    mTrack->getCardinalRep()->extrapolateToPoint( dcaState, mPV );
+                } else {
+                    mTrack->getCardinalRep()->extrapolateToLine( dcaState, mPV, beamDirection );
+                }
                 this->mDCA = dcaState.getPos();
             } catch ( genfit::Exception &e ) {
                 LOG_ERROR << "CANNOT GET DCA : GenfitException: " << e.what() << endm;

--- a/StRoot/StFwdTrackMaker/include/Tracker/GenfitTrackResult.h
+++ b/StRoot/StFwdTrackMaker/include/Tracker/GenfitTrackResult.h
@@ -276,11 +276,14 @@ public:
                 // Fix (Issue #27): kForwardVertexConstrained is likewise fit through
                 // a literal 3D point (the found forward vertex), not a line -- same
                 // reasoning as Primary. kBLCVertexConstrained is fit through the
-                // BLC-derived forward vertex point for the same reason.
+                // BLC-derived forward vertex point for the same reason. kFCSConstrained
+                // is also fit through that same BLC vertex point (see setDCA(mBLCVtxPos)
+                // in doFCSConstrainedFitting).
                 TVector3 beamDirection = TVector3(0,0,1);
                 if ( mTrackType == StFwdTrack::kPrimaryVertexConstrained ||
                      mTrackType == StFwdTrack::kForwardVertexConstrained ||
-                     mTrackType == StFwdTrack::kBLCVertexConstrained ) {
+                     mTrackType == StFwdTrack::kBLCVertexConstrained ||
+                     mTrackType == StFwdTrack::kFCSConstrained ) {
                     mTrack->getCardinalRep()->extrapolateToPoint( dcaState, mPV );
                 } else {
                     mTrack->getCardinalRep()->extrapolateToLine( dcaState, mPV, beamDirection );

--- a/StRoot/StFwdTrackMaker/include/Tracker/GenfitTrackResult.h
+++ b/StRoot/StFwdTrackMaker/include/Tracker/GenfitTrackResult.h
@@ -257,8 +257,12 @@ public:
                 auto dcaState = mTrack->getFittedState( 0 );
                 // Fix (Issue #16): PV-constrained tracks benefit from full 3D DCA
                 // (extrapolateToPoint) instead of transverse-only extrapolateToLine.
+                // Fix (Issue #27): kForwardVertexConstrained is likewise fit through
+                // a literal 3D point (the found forward vertex), not a line -- same
+                // reasoning as Primary.
                 TVector3 beamDirection = TVector3(0,0,1);
-                if ( mTrackType == StFwdTrack::kPrimaryVertexConstrained ) {
+                if ( mTrackType == StFwdTrack::kPrimaryVertexConstrained ||
+                     mTrackType == StFwdTrack::kForwardVertexConstrained ) {
                     mTrack->getCardinalRep()->extrapolateToPoint( dcaState, mPV );
                 } else {
                     mTrack->getCardinalRep()->extrapolateToLine( dcaState, mPV, beamDirection );

--- a/StRoot/StFwdTrackMaker/include/Tracker/GenfitTrackResult.h
+++ b/StRoot/StFwdTrackMaker/include/Tracker/GenfitTrackResult.h
@@ -86,10 +86,17 @@ class EventStats {
         mFailedSecondaryRefits = 0;
         mGoodSecondaryRefits = 0;
 
+        mAttemptedBLCVtxFits = 0;
+        mGoodBLCVtxFits = 0;
+        mFailedBLCVtxFits = 0;
+        mGoodBLCVtxRefits = 0;
+        mFailedBLCVtxRefits = 0;
+
         numGlobalFoundHits.clear();
         numBeamlineFoundHits.clear();
         numPrimaryFoundHits.clear();
         numSecondaryFoundHits.clear();
+        numBLCVtxFoundHits.clear();
 
         mGlobalNumEpdFoundHits.clear();
         mBeamlineNumEpdFoundHits.clear();
@@ -105,6 +112,7 @@ class EventStats {
         mBeamlineFitDuration.clear();
         mPrimaryFitDuration.clear();
         mSecondaryFitDuration.clear();
+        mBLCVtxFitDuration.clear();
     }
     int mNumSeeds = 0;
     int mNumEpdHits = 0; // across all track types, did we find an EPD hit?
@@ -139,10 +147,17 @@ class EventStats {
     int mFailedSecondaryRefits = 0;
     int mGoodSecondaryRefits = 0;
 
+    int mAttemptedBLCVtxFits = 0;
+    int mGoodBLCVtxFits = 0;
+    int mFailedBLCVtxFits = 0;
+    int mGoodBLCVtxRefits = 0;
+    int mFailedBLCVtxRefits = 0;
+
     vector<int> numGlobalFoundHits;
     vector<int> numBeamlineFoundHits;
     vector<int> numPrimaryFoundHits;
     vector<int> numSecondaryFoundHits;
+    vector<int> numBLCVtxFoundHits;
 
     vector<int> mGlobalNumEpdFoundHits;
     vector<int> mBeamlineNumEpdFoundHits;
@@ -158,6 +173,7 @@ class EventStats {
     vector<float> mBeamlineFitDuration;
     vector<float> mPrimaryFitDuration;
     vector<float> mSecondaryFitDuration;
+    vector<float> mBLCVtxFitDuration;
 };
 
 class GenfitTrackResult {
@@ -259,10 +275,12 @@ public:
                 // (extrapolateToPoint) instead of transverse-only extrapolateToLine.
                 // Fix (Issue #27): kForwardVertexConstrained is likewise fit through
                 // a literal 3D point (the found forward vertex), not a line -- same
-                // reasoning as Primary.
+                // reasoning as Primary. kBLCVertexConstrained is fit through the
+                // BLC-derived forward vertex point for the same reason.
                 TVector3 beamDirection = TVector3(0,0,1);
                 if ( mTrackType == StFwdTrack::kPrimaryVertexConstrained ||
-                     mTrackType == StFwdTrack::kForwardVertexConstrained ) {
+                     mTrackType == StFwdTrack::kForwardVertexConstrained ||
+                     mTrackType == StFwdTrack::kBLCVertexConstrained ) {
                     mTrack->getCardinalRep()->extrapolateToPoint( dcaState, mPV );
                 } else {
                     mTrack->getCardinalRep()->extrapolateToLine( dcaState, mPV, beamDirection );

--- a/StRoot/StFwdTrackMaker/include/Tracker/GenfitTrackResult.h
+++ b/StRoot/StFwdTrackMaker/include/Tracker/GenfitTrackResult.h
@@ -271,6 +271,31 @@ public:
 
         }
     }
+
+    /** @brief Fix (Issue #24): re-read scalar fields (momentum, charge,
+     *  convergence, chi2) from the current mTrack fitted state. Call after
+     *  in-place modification of mTrack (e.g. the tight-sigma warm fit) to
+     *  propagate the updated state without replacing the shared_ptr.
+     */
+    void refreshFromTrack() {
+        if ( !mTrack ) return;
+        try {
+            auto cr = mTrack->getCardinalRep();
+            auto fs = mTrack->getFitStatus(cr);
+            if ( !fs ) return;
+            mIsFitConverged          = fs->isFitConverged();
+            mIsFitConvergedFully     = fs->isFitConvergedFully();
+            mIsFitConvergedPartially = fs->isFitConvergedPartially();
+            mNFailedPoints           = fs->getNFailedPoints();
+            mCharge                  = fs->getCharge();
+            mChi2                    = fs->getChi2();
+            if ( mIsFitConverged )
+                mMomentum = cr->getMom( mTrack->getFittedState(0, cr) );
+        } catch ( genfit::Exception &e ) {
+            LOG_WARN << "refreshFromTrack: " << e.what() << endm;
+        } catch (...) {}
+    }
+
     size_t numFtt() const {
         size_t n = 0;
         for ( auto hit : mSeed ){

--- a/StRoot/StFwdTrackMaker/include/Tracker/TrackFitter.h
+++ b/StRoot/StFwdTrackMaker/include/Tracker/TrackFitter.h
@@ -604,16 +604,16 @@ class TrackFitter {
      * @param seedPos : seed position
      * @param Vertex : primary vertex
      */
-    bool setupTrack(Seed_t trackSeed, TVector3 *externalSeedMom = nullptr ) {
-        
+    bool setupTrack(Seed_t trackSeed, TVector3 *externalSeedMom = nullptr, int externalCharge = 0 ) {
+
         mCurrentTrackSeed = trackSeed;
         // setup the track fit seed parameters
         GenericFitSeeder gfs;
         mCurrentSeedCharge = 0; // explicitly reset because a zero charge indicates a failed seed
-        gfs.makeSeed(   trackSeed, 
-                        mCurrentSeedPosition, 
-                        mCurrentSeedMomentum, 
-                        mCurrentSeedCharge 
+        gfs.makeSeed(   trackSeed,
+                        mCurrentSeedPosition,
+                        mCurrentSeedMomentum,
+                        mCurrentSeedCharge
                     );
         if ( mCurrentSeedMomentum.Perp() > 1000 ) {
             LOG_WARN << "Seed momentum is too high, setting to (0,0,1)" << endm;
@@ -623,11 +623,18 @@ class TrackFitter {
         if ( externalSeedMom != nullptr ) {
             LOG_INFO << "Note: Using externally provided seed momentum" << endm;
             mCurrentSeedMomentum = *externalSeedMom;
-        } else {
-            // mCurrentSeedMomentum.SetXYZ(0, 0, 10);
         }
 
-        LOG_DEBUG << "Setting track fit seed position = " << TString::Format( "(px=%f, py=%f, pz=%f)", mCurrentSeedPosition.X(), mCurrentSeedPosition.Y(), mCurrentSeedPosition.Z() )  << endm; 
+        // Fix (Issue #19): when the global fit has a reliable charge, propagate it
+        // directly instead of re-deriving from GenericFitSeeder::averageCurvature.
+        // For near-straight forward tracks (curvature ~= 0) the signed curvature is
+        // numerically unstable and flips the charge sign ~20% of the time.
+        if ( externalCharge != 0 ) {
+            LOG_INFO << "Note: Using externally provided seed charge = " << externalCharge << endm;
+            mCurrentSeedCharge = externalCharge;
+        }
+
+        LOG_DEBUG << "Setting track fit seed position = " << TString::Format( "(px=%f, py=%f, pz=%f)", mCurrentSeedPosition.X(), mCurrentSeedPosition.Y(), mCurrentSeedPosition.Z() )  << endm;
         LOG_DEBUG << "Setting track fit seed momentum = " << TString::Format( "(%f, %f, %f)", mCurrentSeedMomentum.X(), mCurrentSeedMomentum.Y(), mCurrentSeedMomentum.Z() ) << endm;
         if ( mCurrentSeedMomentum.Perp() > 1e-5 && (mCurrentSeedMomentum.Perp() / mCurrentSeedMomentum.Pz()) > 1e-5 ) {
             LOG_DEBUG << "\t" << TString::Format( "(pT=%f, eta=%f, phi=%f)", mCurrentSeedMomentum.Perp(), mCurrentSeedMomentum.Eta(), mCurrentSeedMomentum.Phi() ) << endm;
@@ -817,7 +824,7 @@ class TrackFitter {
      * @param seedMomentum : seed momentum (can be from MC)
      * @return void : the results can be accessed via the getTrack() method
      */
-    long long fitTrack(Seed_t trackSeed, TVector3 *seedMomentum = 0) {
+    long long fitTrack(Seed_t trackSeed, TVector3 *seedMomentum = 0, int seedCharge = 0) {
         long long itStart = FwdTrackerUtils::nowNanoSecond();
         LOG_DEBUG << "Fitting track with " << trackSeed.size() << " FWD Measurements" << endm;
 
@@ -832,7 +839,7 @@ class TrackFitter {
         /******************************************************************************************************************
 		 * Setup the track fit seed parameters and objects
 		 ******************************************************************************************************************/
-        bool valid = setupTrack(trackSeed, seedMomentum);
+        bool valid = setupTrack(trackSeed, seedMomentum, seedCharge);
         if ( !valid ){
             LOG_ERROR << "Failed to setup track for fit" << endm;
             return -1;

--- a/StRoot/StFwdTrackMaker/include/Tracker/TrackFitter.h
+++ b/StRoot/StFwdTrackMaker/include/Tracker/TrackFitter.h
@@ -199,6 +199,17 @@ class TrackFitter {
             }
         }
 
+        // Fix (Issue #24): warm-start KalmanFitter, a simple forward/backward
+        // Kalman with a small blowUpFactor. Used to refine an already-converged
+        // track with tight FST r+phi sigma (pitch/sqrt12) without the instability
+        // caused by blowing up the covariance 1e9x each iteration. Deliberately
+        // outside the kVerbose block above -- it must always be initialized, not
+        // only when verbose logging is on.
+        mWarmFitter = std::unique_ptr<genfit::KalmanFitter>(
+            new genfit::KalmanFitter(20, 1e-3, 1e3, true /*sqrt formalism*/)
+        );
+        mWarmFitter->setBlowUpFactor( 1e6 ); // large enough to reset, small enough vs RefTrack 1e9
+        mWarmFitter->setMaxFailedHits(-1);
 
     } // setupGenfitKalmanFitter
 
@@ -855,6 +866,89 @@ class TrackFitter {
         return duration;
     } // fitTrack
 
+    /**
+     * @brief Fix (Issue #24): warm-start refinement of mFitTrack using tight FST
+     *  sigma (pitch/sqrt12 for both r and phi).
+     *  Steps:
+     *   1. Re-seed mFitTrack with current fitted momentum (warm start).
+     *   2. Tighten FST U (radial) and V (phi) covariance in-place by factor 12.
+     *   3. Run mWarmFitter (KalmanFitter, blowUpFactor=1e6) on mFitTrack.
+     *  mFitTrack is left in the tight-sigma fitted state on success; caller calls
+     *  gtr.refreshFromTrack() to propagate updated momentum, charge, and covariance.
+     *  No restore: every subsequent fitTrack() creates a new shared_ptr<genfit::Track>.
+     *  @return true if warm fit converged
+     */
+    bool warmFitFstTightSigma( Seed_t &seed ) {
+        if ( !mFitTrack || !mWarmFitter ) return false;
+
+        // Step 1: re-seed from fitted state
+        try {
+            auto cr  = mFitTrack->getCardinalRep();
+            auto msp = mFitTrack->getFittedState(0, cr);
+            if ( msp.getMom().Mag() < 0.05 ) return false;
+            // set seed state = fitted pos+mom so warm fitter starts from good estimate
+            mFitTrack->setStateSeed( msp.getPos(), msp.getMom() );
+            TMatrixDSym warmCov(6); warmCov.Zero();
+            double p2 = msp.getMom().Mag2();
+            for(int i=0;i<3;i++) warmCov(i,i) = 0.01;       // 1mm pos uncertainty
+            for(int i=3;i<6;i++) warmCov(i,i) = 0.01 * p2;  // 10% mom uncertainty
+            mFitTrack->setCovSeed(warmCov);
+        } catch (...) { return false; }
+
+        // Step 2: tighten FST U (radial) and V (phi) covariance in-place.
+        // The 2x2 local plane covariance is stored as rawHitCov_ in each PlanarMeasurement.
+        // U = radial direction, V = azimuthal direction.
+        // Both start from full pitch in the initial fit (to keep the Kalman search window wide).
+        // Here, post-convergence, hits are already associated -- safe to tighten both to pitch/sqrt12.
+        // We divide all 4 elements by scale = 12 = (pitch_full/pitch_sqrt12)^2.
+        const float scale = 12.f;  // (full_pitch / (pitch/sqrt12))^2
+        std::vector<std::pair<genfit::AbsMeasurement*,TMatrixDSym>> savedMeas;
+        for (int ip = 0; ip < (int)mFitTrack->getNumPoints(); ip++) {
+            auto tp = mFitTrack->getPointWithMeasurement(ip);
+            if (!tp) continue;
+            for (int im = 0; im < (int)tp->getNumRawMeasurements(); im++) {
+                auto meas = tp->getRawMeasurement(im);
+                if (!meas) continue;
+                // Identify FST hits by their detId (kFstId) stored in AbsMeasurement.
+                // For PlanarMeasurements: detId = fh->_detid = kFstId or kFttId.
+                // For spacepoints (BLC): detId may be kTpcId (beamline/PV) or kFcsPresId.
+                // Only tighten phi on FST PlanarMeasurements.
+                if ( meas->getDetId() != kFstId ) continue; // skip non-FST (FTT, beamline, EPD)
+                TMatrixDSym origCov = meas->getRawHitCov(); // save
+                savedMeas.push_back({meas, origCov});
+                // Tighten both C_UU (radial) and C_VV (phi) -- and cross-terms -- by scale=12.
+                // This brings full-pitch sigma down to pitch/sqrt12 for both directions.
+                TMatrixDSym tightCov = origCov;
+                tightCov(0,0) /= scale;
+                tightCov(1,1) /= scale;
+                tightCov(0,1) /= scale;
+                tightCov(1,0) /= scale;
+                meas->setRawHitCov(tightCov);
+            }
+        }
+
+        // Step 3: run KalmanFitter on mFitTrack IN-PLACE with tight sigma.
+        // mFitTrack is left in the tight-sigma fitted state -- the caller (refitTrack)
+        // calls gtr.refreshFromTrack() to pick up the updated momentum, charge,
+        // covariance, and convergence flags. No restore is needed because every
+        // subsequent fitTrack() call creates a brand-new shared_ptr<genfit::Track>.
+        bool converged = false;
+        try {
+            mWarmFitter->processTrack(mFitTrack.get());
+            mFitTrack->checkConsistency();
+            mFitTrack->determineCardinalRep();
+            auto status = mFitTrack->getFitStatus();
+            converged = status && status->isFitConverged();
+        } catch (genfit::Exception &e) {
+            LOG_WARN << "warmFitFstTightSigma exception: " << e.what() << endm;
+            // Restore measurement covariances so mFitTrack is at least self-consistent
+            for (auto &sv : savedMeas) sv.first->setRawHitCov(sv.second);
+        } catch (...) {
+            for (auto &sv : savedMeas) sv.first->setRawHitCov(sv.second);
+        }
+        return converged;
+    }
+
     genfit::SharedPlanePtr getPlaneFor( FwdHit * fh ){
         
         // sTGC
@@ -892,6 +986,9 @@ class TrackFitter {
 
     // Main GenFit fitter instance
     std::unique_ptr<genfit::AbsKalmanFitter> mFitter = nullptr;
+    // Warm-start second-pass fitter (Issue #24) -- see setupGenfitKalmanFitter()
+    // and warmFitFstTightSigma().
+    std::unique_ptr<genfit::KalmanFitter> mWarmFitter = nullptr;
 
     // PDG codes for the default plc type for fits
     static const int mPdgPiPlus = 211;

--- a/StRoot/StFwdTrackMaker/macro/mudst/fwd_afterburner_db.C
+++ b/StRoot/StFwdTrackMaker/macro/mudst/fwd_afterburner_db.C
@@ -4,6 +4,8 @@
 // that is a valid shebang to run script as executable, but with only one arg
 
 #include <typeinfo.h>
+#include <fstream>
+#include <string>
 
 // Fast fwd tracking without DB
 // bool runDb = false;
@@ -33,6 +35,12 @@ bool refillMuDst = false;
 bool runFwdQa = false;
 bool runFitQa = false;
 bool runPico = true;
+// Unbiased (hit-removed) FST/FTT residuals (StFwdAlignmentMaker) -- see
+// proposal_alignment_path.txt. Off by default: costs ~(num FST+FTT planes)
+// extra refits per track, not meant for routine running. Set at runtime
+// via fwd_afterburner_db()'s enableAlignment parameter (see signature below),
+// not by editing this default.
+bool runFwdAlignment = false;
 
 // Memory Baseline
 // bool runDb = false;
@@ -47,10 +55,17 @@ bool runPico = true;
 #include "StMemStat.h"
 
 void loadLibs();
-//void fwd_afterburner(const Char_t * fileList = "st_physics_23037002_raw_1000064.MuDst.root",size_t nEvents = 100, int debug=0){
-void fwd_afterburner(const Char_t * fileList = "root://xrdstar.rcf.bnl.gov:1095//home/starlib/home/starreco/reco/production_pp500_2022/ReversedFullField/P24ia/2022/108/23108014/st_fwd_23108014_raw_2000026.MuDst.root",size_t nEvents = 100, int debug=0){
+// extraFileList: optional path to a plain text file, one MuDst.root path per
+// line, to Add() onto the same TChain as fileList -- StMuDstMaker's own
+// constructor does NOT auto-detect a .list/.lis fileList argument the way
+// some other STAR IO makers do. Empty (default) = old single-file behavior.
+// enableAlignment: turns on StFwdAlignmentMaker for THIS invocation only, no
+// source edit/rebuild needed.
+void fwd_afterburner_db(const Char_t * fileList = "root://xrdstar.rcf.bnl.gov:1095//home/starlib/home/starreco/reco/production_pp500_2022/ReversedFullField/P24ia/2022/108/23108014/st_fwd_23108014_raw_2000026.MuDst.root",size_t nEvents = 100, int debug=0, const char* extraFileList="", bool enableAlignment=false){
 	cout << "FileList: " << fileList << endl;
 	cout << "nEvents: " << nEvents << endl;
+	cout << "enableAlignment: " << enableAlignment << endl;
+	runFwdAlignment = enableAlignment;
 
 	// First load some shared libraries we need
 	loadLibs();
@@ -68,6 +83,18 @@ void fwd_afterburner(const Char_t * fileList = "root://xrdstar.rcf.bnl.gov:1095/
 							1
 							);
 	TChain& muDstChain = *muDstMaker.chain();
+	if (extraFileList && strlen(extraFileList) > 0) {
+		std::ifstream extraIn(extraFileList);
+		std::string extraLine;
+		int nAdded = 0;
+		while (std::getline(extraIn, extraLine)) {
+			if (extraLine.empty()) continue;
+			muDstChain.Add(extraLine.c_str());
+			nAdded++;
+		}
+		cout << "Added " << nAdded << " extra MuDst files from " << extraFileList
+		     << " -- chain now has " << muDstChain.GetEntries() << " events total" << endl;
+	}
 	printf( "MuDst file has %d events available in tree\n", muDstChain.GetEntries());
 	
 	/*******************************************************************************************/
@@ -87,8 +114,10 @@ void fwd_afterburner(const Char_t * fileList = "root://xrdstar.rcf.bnl.gov:1095/
 	/*******************************************************************************************/
 
 	/*******************************************************************************************/
-	// Setup Fcs Database if needed
-	if ( (runFcsChain && runDb) || runFitQa){
+	// Setup Fcs Database if needed. Note: no longer requires runFcsChain --
+	// StFcsDb (beamline-from-DB) is needed for BLC track/vertex fitting even
+	// when the full FCS reconstruction chain is off.
+	if ( runDb || runFitQa){
 		StFcsDbMaker * fcsDb = new StFcsDbMaker();
 		chain->AddMaker(fcsDb);
 		// fcsDb->SetDebug();
@@ -147,11 +176,31 @@ void fwd_afterburner(const Char_t * fileList = "root://xrdstar.rcf.bnl.gov:1095/
 		fwdTrack->setFstHitSource( 2 /* = MUDST */);
 		fwdTrack->setFttHitSource( 1 /* = STEVENT */);
 
+		if (runDb) fwdTrack->setUseBeamlineFromDB( true ); // use measured beamline for BLC; off for MC
 
 		// fwdTrack->setConfigKeyValue("TrackFitter:doBeamlineTrackFitting", false);
         // fwdTrack->setConfigKeyValue("TrackFitter:doPrimaryTrackFitting", false);
         // fwdTrack->setConfigKeyValue("TrackFitter:doSecondaryTrackFitting", false);
         // skip finding fwd vertices
+	}
+
+	const int kNAlignTypes = 1;
+	int alignTypesToRun[kNAlignTypes] = {4}; // BLCVtx only by default; add 0 (Global)
+	                                          // back to this array for a clean-baseline
+	                                          // comparison sample too.
+	StFwdAlignmentMaker *fwdAlignments[kNAlignTypes] = {NULL};
+	if (runFwdAlignment && runFwdChain){
+		// Unbiased (hit-removed) residuals -- see proposal_alignment_path.txt.
+		// One instance per track type.
+		const char* alignTypeName[6] = {"Global","BLC","Primary","FwdVtx","BLCVtx","FCSConstrained"};
+		for (int i = 0; i < kNAlignTypes; i++) {
+			int rt = alignTypesToRun[i];
+			TString alignName( gSystem->BaseName(inMuDstFile) );
+			alignName.ReplaceAll(".MuDst.root", Form(".FwdAlignment_%s.root", alignTypeName[rt]));
+			fwdAlignments[i] = new StFwdAlignmentMaker(alignName, Form("fwdAlignment_%s", alignTypeName[rt]));
+			fwdAlignments[i]->setTrackMaker(fwdTrack);
+			fwdAlignments[i]->setTrackType((UChar_t)rt);
+		}
 	}
 
 
@@ -275,6 +324,12 @@ void fwd_afterburner(const Char_t * fileList = "root://xrdstar.rcf.bnl.gov:1095/
 	stmem.Summary();
 	/*******************************************************************************************/
 
+	// chain->Finish() is disabled below (pre-existing), so StFwdAlignmentMaker's
+	// output may not get flushed either -- call ours explicitly so it isn't silently lost.
+	for (int i = 0; i < kNAlignTypes; i++) {
+		if (fwdAlignments[i]) fwdAlignments[i]->Finish();
+	}
+
 	// Chain Finish
 	// if (nEntries > 1) {
 	// 	cout << "FINISH up" << endl;
@@ -344,6 +399,7 @@ void loadLibs(){
 	gSystem->Load("libKiTrack");
 	gSystem->Load("libXMLIO.so");
 	gSystem->Load( "StFwdTrackMaker.so" );
+	gSystem->Load( "StFwdAlignmentMaker.so" );
 	gSystem->Load( "StFwdUtils.so" );
 	gSystem->Load("libStEpdUtil.so");
 	gSystem->Load("StStarLogger.so");

--- a/StRoot/StMuDSTMaker/COMMON/StMuPrimaryVertex.h
+++ b/StRoot/StMuDSTMaker/COMMON/StMuPrimaryVertex.h
@@ -64,6 +64,7 @@ class StMuPrimaryVertex : public TObject {
    void          setIdTruth(Int_t idtru,Int_t qatru=0) {mIdTruth = (UShort_t) idtru; mQuality = (UShort_t) qatru;}
    void          setIdParent(Int_t id) {mIdParent = id;}
    Bool_t        isBeamConstrained() const {return TESTBIT(mFlag,kBEAMConstrVtxId);}
+   Bool_t        isBLCVtx()         const {return TESTBIT(mFlag,kBLCVtxId);}
    virtual void     Print(Option_t *option="") const; ///< Print essential vertex info
 
   ClassDef(StMuPrimaryVertex,8)

--- a/StRoot/StPicoDstMaker/StPicoDstMaker.cxx
+++ b/StRoot/StPicoDstMaker/StPicoDstMaker.cxx
@@ -2660,6 +2660,21 @@ void StPicoDstMaker::fillFwdTracks() {
     new((*(mPicoArrays[StPicoArrays::FwdVertex]))[counter]) StPicoFwdVertex(picoFwdVertex);
   } // for each primary vertex
 
+  // Fill BLC vertex into StPicoEvent (one per event, stored as scalar fields)
+  StPicoEvent *picoEvent = (StPicoEvent*)mPicoArrays[StPicoArrays::Event]->At(0);
+  if ( picoEvent ) {
+    for ( size_t i = 0; i < evt->numberOfPrimaryVertices(); i++ ){
+      StPrimaryVertex *evVertex = evt->primaryVertex(i);
+      if (!evVertex || !evVertex->isBLCVertex()) continue;
+      picoEvent->setBLCVertexPosition( evVertex->position().x(), evVertex->position().y(), evVertex->position().z() );
+      double blcCov[6]; evVertex->covarianceMatrix(blcCov);
+      picoEvent->setBLCVertexSigmaZ( (Float_t)sqrt(blcCov[5]) );  // cov[5] = sigZ^2
+      picoEvent->setBLCVertexNTracks( (UShort_t)evVertex->numTracksUsedInFinder() );
+      LOG_DEBUG << "Added BLC vertex to StPicoEvent z=" << evVertex->position().z() << endm;
+      break; // only one BLC vertex per event
+    }
+  }
+
 } //fillFwdTracks
 
 //_________________

--- a/StRoot/StPicoEvent/StPicoEvent.cxx
+++ b/StRoot/StPicoEvent/StPicoEvent.cxx
@@ -36,7 +36,8 @@ StPicoEvent::StPicoEvent(): TObject(),
   mZdcSumAdcEast(0), mZdcSumAdcWest(0),
   mZdcSmdEastHorizontal{}, mZdcSmdEastVertical{}, mZdcSmdWestHorizontal{}, mZdcSmdWestVertical{},
   mBbcAdcEast{}, mBbcAdcWest{}, mHighTowerThreshold{}, mJetPatchThreshold{},
-  mETofHitMultiplicity(0), mETofDigiMultiplicity(0), mETofGoodEventFlag{}, mNumberOfPrimaryTracks(0), mZdcUnAttenuated{} {
+  mETofHitMultiplicity(0), mETofDigiMultiplicity(0), mETofGoodEventFlag{}, mNumberOfPrimaryTracks(0), mZdcUnAttenuated{},
+  mBLCVtxX(0), mBLCVtxY(0), mBLCVtxZ(0), mBLCVtxSigmaZ(0), mBLCVtxNTracks(0) {
 
   // Default constructor
   if( !mTriggerIds.empty() ) {
@@ -153,6 +154,13 @@ StPicoEvent::StPicoEvent(const StPicoEvent &event) : TObject() {
   for(int iIter=0; iIter<108; iIter++) {
     mETofHasPulsersFlag[iIter] = event.mETofHasPulsersFlag[iIter];
   }
+
+  // BLC vertex
+  mBLCVtxX      = event.mBLCVtxX;
+  mBLCVtxY      = event.mBLCVtxY;
+  mBLCVtxZ      = event.mBLCVtxZ;
+  mBLCVtxSigmaZ = event.mBLCVtxSigmaZ;
+  mBLCVtxNTracks = event.mBLCVtxNTracks;
 }
 
 //_________________

--- a/StRoot/StPicoEvent/StPicoEvent.h
+++ b/StRoot/StPicoEvent/StPicoEvent.h
@@ -54,6 +54,13 @@ class StPicoEvent : public TObject {
   /// Return primary vertex position error
   TVector3 primaryVertexError() const
   { return TVector3(mPrimaryVertexErrorX,mPrimaryVertexErrorY,mPrimaryVertexErrorZ); }
+  /// Return BLC vertex position (beam-line-constrained; zero if not found)
+  TVector3 blcVertex() const
+  { return TVector3(mBLCVtxX, mBLCVtxY, mBLCVtxZ); }
+  /// Return BLC vertex z sigma (cm)
+  Float_t  blcVertexSigmaZ()  const { return mBLCVtxSigmaZ; }
+  /// Return number of tracks used in BLC vertex fit (0 = not found)
+  UShort_t blcVertexNTracks() const { return mBLCVtxNTracks; }
   /// Return primary vertex ranking
   Float_t  ranking() const             { return mRanking; }
   /// Return number of tracks that matched BEMC
@@ -274,6 +281,13 @@ class StPicoEvent : public TObject {
   { mPrimaryVertexErrorX=vtxPosErr.X(); mPrimaryVertexErrorY=vtxPosErr.Y(); mPrimaryVertexErrorZ=vtxPosErr.Z(); }
   /// Set primary vertex ranking
   void setPrimaryVertexRanking(Float_t ranking) { mRanking = (Float_t)ranking; }
+  /// Set BLC vertex position (x,y,z) in cm
+  void setBLCVertexPosition(Float_t x, Float_t y, Float_t z)
+  { mBLCVtxX = x; mBLCVtxY = y; mBLCVtxZ = z; }
+  /// Set BLC vertex z sigma in cm
+  void setBLCVertexSigmaZ(Float_t s)  { mBLCVtxSigmaZ = s; }
+  /// Set number of tracks used in BLC vertex fit
+  void setBLCVertexNTracks(UShort_t n) { mBLCVtxNTracks = n; }
   /// Set number of BEMC-matched tracks
   void setNumberOfBEMCMatch(Int_t n)            { mNBEMCMatch = (UShort_t)n; }
   //// Set number of TOF-matched tracks
@@ -625,10 +639,21 @@ protected:
   /// ZDC unattenuated: 0 - east, 1 - west
   UShort_t mZdcUnAttenuated[2];
 
+  /// BLC vertex position x (cm); 0 if not found
+  Float_t  mBLCVtxX;
+  /// BLC vertex position y (cm); 0 if not found
+  Float_t  mBLCVtxY;
+  /// BLC vertex position z (cm); 0 if not found
+  Float_t  mBLCVtxZ;
+  /// BLC vertex z sigma (cm); 0 if not found
+  Float_t  mBLCVtxSigmaZ;
+  /// Number of tracks used in BLC vertex fit; 0 if not found
+  UShort_t mBLCVtxNTracks;
+
 #if defined (__TFG__VERSION__)
   ClassDef(StPicoEvent, 10)
 #else /* ! __TFG__VERSION__ */
-  ClassDef(StPicoEvent, 8)
+  ClassDef(StPicoEvent, 9)
 #endif
 };
 

--- a/StRoot/StPicoEvent/StPicoFwdTrack.h
+++ b/StRoot/StPicoEvent/StPicoFwdTrack.h
@@ -20,7 +20,8 @@ class StPicoFwdTrack : public TObject {
     
 
 public:
-    enum StPicoFwdTrackType { kGlobal=0, kBeamlineConstrained=1, kPrimaryVertexConstrained=2, kForwardVertexConstrained=3 };
+    // kBLCVertexConstrained added; bit layout expanded to 5+3 (matches StFwdTrack)
+    enum StPicoFwdTrackType { kGlobal=0, kBeamlineConstrained=1, kPrimaryVertexConstrained=2, kForwardVertexConstrained=3, kBLCVertexConstrained=4 };
     /// Constructor
     StPicoFwdTrack(  );
     /// Copy constructor
@@ -66,12 +67,12 @@ public:
     Float_t dcaZ() const { return mDCAZ; }
     // Index of the primary vertex used in the fit
     UChar_t vertexIndex() const {
-        // extract bits 7…2:
-        return (mVtxIndex >> 2) & 0x3F;
+        // bits 7…3 (5 bits) — expanded from 6 bits
+        return (mVtxIndex >> 3) & 0x1F;
     }
     UChar_t trackType() const {
-        // extract bits 1…0:
-        return mVtxIndex & 0x03;
+        // bits 2…0 (3 bits) — expanded from 2 bits to hold kBLCVertexConstrained=4
+        return mVtxIndex & 0x07;
     }
     // Index of the corresponding Global Track if Primary, BLC, or FwdVertex constrained tracks
     UShort_t globalTrackIndex() const { return mGlobalTrackIndex; }
@@ -79,6 +80,7 @@ public:
     bool isBeamLineConstrainedTrack() const { return (trackType() == StPicoFwdTrack::kBeamlineConstrained); }
     bool isPrimaryTrack() const { return (trackType() == StPicoFwdTrack::kPrimaryVertexConstrained); }
     bool isFwdVertexConstrainedTrack() const { return (trackType() == StPicoFwdTrack::kForwardVertexConstrained); }
+    bool isBLCVertexConstrainedTrack() const { return (trackType() == StPicoFwdTrack::kBLCVertexConstrained); }
 
      // access ecal match indices
      UChar_t ecalMatchIndex( Int_t i ) const { return (i < (Int_t)mEcalMatchIndex.size()) ? mEcalMatchIndex[i] : 0; }


### PR DESCRIPTION

- **StFwdAlignmentMaker**: new standalone maker for alignment studies — for each track, does an unbiased lea
ve-one-out refit per FST/FTT hit (hit removed before refit, so the residual isn't pulled toward the hit) and
 writes a standalone ROOT tree of hit-vs-projection residuals. Off by default; doesn't touch StEvent/MuDst/P
icoDst.
- **Macro wiring** (`fwd_afterburner_db.C`): fixed a function-name/file-name mismatch that broke root4star's
 auto-call convention; added an `extraFileList` option to chain multiple MuDst files; wired up `enableAlignm
ent` to turn on the new alignment maker; wired up `setUseBeamlineFromDB(true)` (added several commits back b
ut never actually turned on in this macro); loosened the FCS DB maker condition so StFcsDb is built whenever
 DB mode is on, not just when the full FCS chain runs.

Depends on PR6 (references `StFwdAlignmentMaker`) and PR5 (calls `setUseBeamlineFromDB`).
