### PR TITLE
Fix FTT off-axis matching, reverseHardwareMap multi-channel, StFttSimHitMaker, afterburner speedup

### DIFF
--- a/StDb/idl/fttDataWindowsB.idl
+++ b/StDb/idl/fttDataWindowsB.idl
@@ -7,7 +7,7 @@
 */
 
 struct fttDataWindowsB {
-	short uuid[385]; /* fob(1-96) x vmm(1-4) = index 1 - 384 */
+	short uuid[385]; /* index = StFttDb::vmmId(hit) [0-383] */
 	octet mode[385]; /* 0 = timebin, 1 = bcid */
 	short min[385]; /* time window min > -32768 */
 	short max[385]; /* time window max < 32768 */

--- a/StRoot/StFttClusterMaker/StFttClusterMaker.cxx
+++ b/StRoot/StFttClusterMaker/StFttClusterMaker.cxx
@@ -462,6 +462,25 @@ std::vector<StFttCluster*> StFttClusterMaker::FindClusters( std::vector< StFttRa
         clu->setQuadrant    ( maxAdcHit->quadrant    ( ) );
         clu->setRow         ( maxAdcHit->row         ( ) );
         clu->setOrientation ( maxAdcHit->orientation ( ) );
+        // Fix (2026-07-17): this was the only max-ADC-hit field never copied onto the
+        // cluster, so StFttCluster::maxStripLength() stayed at its -999 default forever.
+        // That -999 flows into StFttClusterPointMaker's row-position formula
+        // (YX_StripGroupEdge[row] + maxStripLength()/2), producing a huge negative local
+        // value that -- combined with the per-quadrant sign flips -- swaps which end of
+        // each row lands near vs. far from y=0. See jpsi/electron_45.html for the
+        // derivation (this single line explains the top/bottom+north/south swap and the
+        // bowtie shape both).
+        clu->setMaxStripLength( maxAdcHit->stripLength( ) );
+        // Fix (2026-07-18): same bug shape as maxStripLength above -- setMaxStripCenter
+        // was also never called, so StFttCluster::maxStripCenter() stayed at its -999
+        // default forever. StFttClusterPointMaker used a row-averaged fallback
+        // (YX_StripGroupEdge[row]+maxStripLength/2) for the off-axis coordinate instead,
+        // which collapses the off-axis coordinate to one constant value for the ~92% of
+        // same-row hits sharing an identical maxStripLength, discarding real per-strip
+        // resolution. maxAdcHit->stripCenter() comes from the same scMapXY table already
+        // used (correctly) for the precision coordinate via cluster x()/y() -- no row
+        // dependence in that lookup, so this is safe for all rows, not just row 0.
+        clu->setMaxStripCenter( maxAdcHit->stripCenter( ) );
 
         // Now find the cluster edges
         size_t left = anchor, right = anchor;

--- a/StRoot/StFttClusterPointMaker/StFttClusterPointMaker.cxx
+++ b/StRoot/StFttClusterPointMaker/StFttClusterPointMaker.cxx
@@ -124,7 +124,9 @@ Int_t StFttClusterPointMaker::Make() {
 
     //organize clusters by rob and orientation
     for ( StFttCluster* clu : mFttCollection->clusters() ) {
-        // group clusters by rob (1-16, 4 quadrants of 4 sTGC planes) and strip orientation
+        // group clusters by rob (0-15, 4 quadrants of 4 sTGC planes -- rob(StFttCluster*)
+        // is 0-based, unlike rob(StFttRawHit*); this array is sized [16] to match) and
+        // strip orientation
         UChar_t rob = mFttDb->rob( clu );
         UChar_t orient = clu->orientation();
         if (mDebug){

--- a/StRoot/StFttClusterPointMaker/StFttClusterPointMaker.cxx
+++ b/StRoot/StFttClusterPointMaker/StFttClusterPointMaker.cxx
@@ -200,8 +200,14 @@ void StFttClusterPointMaker::MakeLocalPoints(UChar_t Rob) {
         covMatrix[0][1] = 0;
         covMatrix[1][0] = 0;
 
+        // Fix (2026-07-18): use the fired strip's OWN center (maxStripCenter(), now
+        // populated -- see StFttClusterMaker.cxx) instead of the row-averaged
+        // YX_StripGroupEdge[row]+maxStripLength/2 fallback, which collapsed the
+        // off-axis coordinate to one constant value for ~92% of same-row hits
+        // (identical maxStripLength), discarding real per-strip resolution
+        // (~3.2mm pitch, per StFttDb::stripPitch and Row1.txt).
         point->setX( clu_x->x() );
-        point->setY( mFttDb->YX_StripGroupEdge[clu_x->row()]+clu_x->maxStripLength()/2. );
+        point->setY( clu_x->maxStripCenter() );
         point->setSigmaX(clu_x->sigma());
         point->setSigmaY(clu_x->maxStripLength()/sqrt(12));
         point->setSigmaXY(0);
@@ -226,7 +232,8 @@ void StFttClusterPointMaker::MakeLocalPoints(UChar_t Rob) {
         covMatrix[0][1] = 0;
         covMatrix[1][0] = 0;
 
-        point->setX(  mFttDb->YX_StripGroupEdge[clu_y->row()]+clu_y->maxStripLength()/2. );
+        // Fix (2026-07-18): see matching comment in the vertical-cluster loop above.
+        point->setX( clu_y->maxStripCenter() );
         point->setY( clu_y->x() );
         point->setSigmaX(clu_y->maxStripLength()/sqrt(12.));
         point->setSigmaY(clu_y->sigma());
@@ -339,15 +346,26 @@ void StFttClusterPointMaker::MakeGlobalPoints() {
         // Z is already in cm since it is just the offset
         global.set( ((x*sx)+dx)/10.0, ((y*sy)+dy)/10.0, z+dz );
 
+        // Fix (2026-07-18): the covariance built in MakeLocalPoints()/MakeHVPoints()
+        // (from maxStripLength() and cluster sigma(), both in mm, per
+        // Row1_StripLength.txt) was never rescaled here even though position just
+        // was (/10 above) -- so cov() stayed in mm^2 forever while everything
+        // downstream (hsx/hsy in FwdTracker.h's findFttStripsNearProjectedState,
+        // and GenFit's own hit-weighting via StFwdHitLoader.cxx's hitCov3) reads it
+        // as if already cm^2. That's a 10x error on sigma (100x on variance) for
+        // every FTT hit ever fit. Variance scales as length^2, so /100 here to
+        // match position's /10.
+        std::vector<std::vector<float>> new_cov(2,std::vector<float>(2,0));
+        new_cov[0][0] = p->cov()[0][0] / 100.0;
+        new_cov[1][1] = p->cov()[1][1] / 100.0;
+        new_cov[0][1] = p->cov()[0][1] / 100.0;
+        new_cov[1][0] = p->cov()[1][0] / 100.0;
         if (p->quadrant() == 1 || p->quadrant() == 3) {
             p->setSigmaXY(-p->sigmaXY());
-            std::vector<std::vector<float>> new_cov(2,std::vector<float>(2,0));
-            new_cov[0][0] = p->cov()[0][0];
-            new_cov[1][1] = p->cov()[1][1];
-            new_cov[0][1] = -p->cov()[0][1];
-            new_cov[1][0] = -p->cov()[1][0];
-            p->setCov(new_cov);
+            new_cov[0][1] = -new_cov[0][1];
+            new_cov[1][0] = -new_cov[1][0];
         }
+        p->setCov(new_cov);
 
         if (mDebug) {
             LOG_INFO << "Global x: " << global.x() << " y: " << global.y() << " z: " << global.z() << endm;

--- a/StRoot/StFttDbMaker/StFttDb.cxx
+++ b/StRoot/StFttDbMaker/StFttDb.cxx
@@ -227,7 +227,7 @@ void StFttDb::loadHardwareMapFromDb( St_fttHardwareMap * dataset ) {
                 uint16_t key = packKey( table[i].feb[j], table[i].vmm[j], table[i].vmm_ch[j] );
                 uint16_t val = packVal( table[i].row[j], table[i].strip[j] );
                 mMap[ key ] = val;
-                rMap[ val ] = key;
+                rMap[ val ].push_back( key ); // a given (row,strip) has one channel per orientation -- keep all of them
             }
             // sample output of first member variable
         }
@@ -264,7 +264,7 @@ void StFttDb::loadHardwareMapFromFile( std::string fn ){
         uint16_t key = packKey( feb, vmm, ch );
         uint16_t val = packVal( row, strip );
         mMap[ key ] = val;
-        rMap[ val ] = key;
+        rMap[ val ].push_back( key ); // a given (row,strip) has one channel per orientation -- keep all of them
         if ( mDebug ){
             printf( "key=%d", key );
             printf( "in=(feb=%d, vmm=%d, ch=%d)\n", feb, vmm, ch );
@@ -652,15 +652,26 @@ bool StFttDb::hardwareMap( StFttRawHit * hit ) const{
 // plane, quad, row and strip can be calculated from the simulation maker
 // the key issue if to figure out which feb, row, and strip is for the selected channel
 bool StFttDb::reverseHardwareMap( int &rob, int &feb, int &vmm, int &ch, int plane, int quad, int row, int strip, UChar_t &orientation ) const {
-    // uint16_t key = packKey( feb, vmm, ch );
     uint16_t val = packVal( row, strip );
-    if ( rMap.count( val ) ){
-        uint16_t key = rMap.at( val );
-        unpackKey( key, feb, vmm, ch );//get the feb, vmm and channel information
-        rob = quad + ( plane *nQuadPerPlane ) + 1;// input plane and quad should start from 0;
-        
-        orientation = getOrientation( rob, feb, vmm, row );
-        return true;
+    if ( !rMap.count( val ) ) return false;
+
+    rob = quad + ( plane *nQuadPerPlane ) + 1;// input plane and quad should start from 0;
+
+    // (row,strip) alone is ambiguous -- both an H and a V (or DiagonalH/DiagonalV
+    // for row 3/4) channel exist there in the real hardware map. If the caller
+    // pre-set orientation to a specific value, return the channel matching it;
+    // if left at kFttUnknownOrientation, return whichever comes first (matches
+    // the old, pre-multi-channel behavior for callers that don't care).
+    UChar_t wantOrientation = orientation;
+    for ( uint16_t key : rMap.at( val ) ) {
+        int f, v, c;
+        unpackKey( key, f, v, c );
+        UChar_t o = getOrientation( rob, f, v, row );
+        if ( wantOrientation == kFttUnknownOrientation || o == wantOrientation ) {
+            feb = f; vmm = v; ch = c;
+            orientation = o;
+            return true;
+        }
     }
     return false;
 }
@@ -668,10 +679,12 @@ bool StFttDb::reverseHardwareMap( int &rob, int &feb, int &vmm, int &ch, int pla
 // plane, quad, row and strip can be calculated from the simulation maker
 // the key issue if to figure out which feb, row, and strip is for the selected channel
 bool StFttDb::reverseHardwareMap( int &feb, int &vmm, int &ch, int row, int strip ) const{
-    // uint16_t key = packKey( feb, vmm, ch );
+    // No rob/orientation available here to disambiguate which of the (row,strip)
+    // channels (H vs V, or DiagonalH vs DiagonalV) is wanted -- returns the first
+    // one on record. Prefer the 9-arg overload when orientation matters.
     uint16_t val = packVal( row, strip );
-    if ( rMap.count( val ) ){
-        uint16_t key = rMap.at( val );
+    if ( rMap.count( val ) && !rMap.at( val ).empty() ){
+        uint16_t key = rMap.at( val ).front();
         unpackKey( key, feb, vmm, ch );//get the feb, vmm and channel information
         return true;
     }

--- a/StRoot/StFttDbMaker/StFttDb.cxx
+++ b/StRoot/StFttDbMaker/StFttDb.cxx
@@ -714,10 +714,12 @@ UChar_t StFttDb::quadrant( StFttRawHit * hit ){
 }
 
 UChar_t StFttDb::rob( StFttRawHit * hit ){
+    // NOTE: 1-based, range [1,16] -- NOT the same convention as rob(StFttCluster*) below.
     return quadrant(hit) + ( plane(hit) * nQuadPerPlane ) + 1;
 }
 
 UChar_t StFttDb::rob( StFttCluster * clu ){
+    // NOTE: 0-based, range [0,15] -- NOT the same convention as rob(StFttRawHit*) above.
     return clu->quadrant() + ( clu->plane() * StFttDb::nQuadPerPlane );
 }
 

--- a/StRoot/StFttDbMaker/StFttDb.cxx
+++ b/StRoot/StFttDbMaker/StFttDb.cxx
@@ -698,7 +698,17 @@ UChar_t StFttDb::plane( StFttRawHit * hit ){
 }
 
 UChar_t StFttDb::quadrant( StFttRawHit * hit ){
-    if ( hit->quadrant() < nQuad )
+    // Bug (found 2026-07-22): was checking against nQuad (=16, total
+    // quadrants across all 4 planes) instead of nQuadPerPlane (=4). Since
+    // the "unset" sentinel kFttUnknownQuadrant=4 is < 16, the check always
+    // passed and the rdo()-1 fallback below never fired for a hit whose
+    // StFttRawHit::mQuadrant hadn't been mapped yet (e.g. anything read
+    // before StFttClusterMaker::ApplyHardwareMap() runs this event --
+    // notably StFttHitCalibMaker::Make(), which calls StFttDb::fob(),
+    // which calls this, and runs earlier in the chain than
+    // ApplyHardwareMap in production). Matches StFttDb::plane()'s
+    // (correct) use of nPlane just above.
+    if ( hit->quadrant() < nQuadPerPlane )
         return hit->quadrant();
     return hit->rdo() - 1;
 }

--- a/StRoot/StFttDbMaker/StFttDb.h
+++ b/StRoot/StFttDbMaker/StFttDb.h
@@ -15,6 +15,7 @@
 #include "StEvent/StEnumerations.h"
 #include <stdint.h>
 #include <map>
+#include <vector>
 
 
 class StFttRawHit;
@@ -174,7 +175,7 @@ public:
   int mTimeCutLow, mTimeCutHigh;
 
   std :: map< uint16_t , uint16_t > mMap;
-  std :: map< uint16_t , uint16_t > rMap; // reverse map 
+  std :: map< uint16_t , std::vector<uint16_t> > rMap; // reverse map -- a given (row,strip) has one channel per orientation (H and V both exist at the same row/strip in the real hardware map, confirmed by scanning the forward map), so this must hold all of them, not just the last one loaded
   //  data windows map
   std :: map< uint16_t , FttDataWindow > dwMap;
   std :: map< int , Float_t > scMapXY; // strip center map 

--- a/StRoot/StFttHitCalibMaker/HitCalibHelper.h
+++ b/StRoot/StFttHitCalibMaker/HitCalibHelper.h
@@ -34,7 +34,14 @@ public:
     }
 
     Short_t time( UShort_t uuid, Short_t dbcid ){
-        return dbcid - dbcidAnchor[ uuid ]; // TODO: handle wrap around?
+        // dbcid is a 12-bit (4096) circular counter -- a channel whose true
+        // anchor sits near the 0/4095 edge would otherwise get hits on the
+        // far side of the wrap reported as a difference near +-4096 instead
+        // of their true small offset. Wrap to the shortest signed distance.
+        Short_t diff = dbcid - dbcidAnchor[ uuid ];
+        if ( diff > 2048 ) diff -= 4096;
+        if ( diff < -2048 ) diff += 4096;
+        return diff;
     }
 
     Short_t anchor( UShort_t uuid ) {

--- a/StRoot/StFttHitCalibMaker/StFttHitCalibMaker.cxx
+++ b/StRoot/StFttHitCalibMaker/StFttHitCalibMaker.cxx
@@ -100,8 +100,13 @@ Int_t StFttHitCalibMaker::Make()
 
     for ( auto rawHit : mFttCollection->rawHits() ) {
 
-        UShort_t fob = (UShort_t)mFttDb->fob( rawHit );
-        UShort_t uuid = rawHit->vmm() + ( StFttDb::nVMMPerFob * fob );
+        // Use StFttDb::vmmId() -- the SAME per-channel key
+        // StFttDb::getTimeCut() uses to look up the DB time-window map
+        // (dwMap). The old fob()-based formula here (vmm + 4*fob, fob
+        // 1-based) computed a DIFFERENT number, off by a constant
+        // +StFttDb::nVMMPerFob (=4), from vmmId() -- the two were
+        // independently written ~4 years apart and never reconciled.
+        UShort_t uuid = (UShort_t)mFttDb->vmmId( rawHit );
 
         mHelper->fill( uuid, rawHit->dbcid() );
 

--- a/StRoot/StFttSimHitMaker/StFttSimHitMaker.cxx
+++ b/StRoot/StFttSimHitMaker/StFttSimHitMaker.cxx
@@ -1,0 +1,325 @@
+#include <cmath>
+#include <map>
+#include <utility>
+
+#include "StFttSimHitMaker.h"
+
+#include "StEvent.h"
+#include "StEnumerations.h"
+#include "StEvent/StEvent.h"
+#include "StEvent/StFttCollection.h"
+#include "StEvent/StFttRawHit.h"
+
+#include "StFttDbMaker/StFttDb.h"
+
+#include "tables/St_g2t_fts_hit_Table.h"
+
+#include "TRandom.h"
+
+ClassImp( StFttSimHitMaker )
+
+//_____________________________________________________________
+StFttSimHitMaker::StFttSimHitMaker( const char* name )
+: StMaker( name ),
+  mEvent( 0 ),
+  mFttCollection( 0 ),
+  mFttDb( 0 )
+{ }
+
+//_____________________________________________________________
+StFttSimHitMaker::~StFttSimHitMaker()
+{ }
+
+//_____________________________________________________________
+Int_t StFttSimHitMaker::Init()
+{
+    return kStOk;
+}
+
+//_____________________________________________________________
+Int_t StFttSimHitMaker::Make()
+{
+    mEvent = (StEvent*)GetInputDS("StEvent");
+    if ( !mEvent ) {
+        mEvent = new StEvent();
+        AddData( mEvent );
+        LOG_INFO << "StFttSimHitMaker::Make() - Creating StEvent" << endm;
+    }
+
+    if ( mEvent->fttCollection() == nullptr ) {
+        LOG_INFO << "StFttSimHitMaker::Make() - Creating FttCollection" << endm;
+        mEvent->setFttCollection( new StFttCollection() );
+    }
+    mFttCollection = mEvent->fttCollection();
+    mFttCollection->rawHits().clear();
+
+    mFttDb = static_cast<StFttDb*>( GetDataSet( "fttDb" ) );
+    if ( !mFttDb ) {
+        LOG_ERROR << "StFttSimHitMaker::Make() - fttDb dataset not found (is StFttDbMaker in the chain, before this maker?), cannot continue" << endm;
+        return kStErr;
+    }
+
+    St_g2t_fts_hit *geantFtt = (St_g2t_fts_hit*)GetDataSet( "geant/g2t_stg_hit" );
+    if ( !geantFtt ) {
+        LOG_WARN << "StFttSimHitMaker::Make() - geant/g2t_stg_hit is empty" << endm;
+        return kStOk;
+    }
+
+    // one truth hit -> one synthetic 3-strip cluster (per orientation, see
+    // header comment); dedupe multiple GEANT steps on the same track+volume,
+    // same convention as StFttClusterPointMaker::MakeGeantPoints()
+    std::map<std::pair<int,int>,int> track_vol_count;
+
+    // Accumulate ADC per physical channel across ALL truth hits this event
+    // before creating any StFttRawHit -- two nearby tracks (or one track's
+    // center strip landing on another's neighbor spill) can legitimately
+    // land on the same channel, and a real DAQ channel reports one summed
+    // ADC value per event, not multiple independent records. See
+    // status_ftt_sim_maker.txt item 9.
+    std::map<long long, ChannelAccum> accum;
+
+    int nTruthHits = 0;
+
+    for ( int i = 0; i < geantFtt->GetNRows(); i++ ) {
+        g2t_fts_hit_st *git = (g2t_fts_hit_st*)geantFtt->At(i);
+        if ( !git ) continue;
+
+        int track_id  = git->track_p;
+        int volume_id = git->volume_id;
+
+        // Dedupe by (track, volume): front/back are genuinely different
+        // physical foils (StFttDb::reverseHardwareMap() now disambiguates
+        // both orientations at a given row/strip -- see status_ftt_sim_maker.txt
+        // item 3), so each gets its own synthetic cluster again.
+        if ( ++track_vol_count[ std::make_pair(track_id, volume_id) ] > 1 ) continue;
+
+        int plane_id = (volume_id - 1) / 100;
+        // front (even volume_id) = vertical/X strips, back (odd) = horizontal/Y strips --
+        // same convention as StFttClusterPointMaker::MakeGeantPoints() / StFttFastSimMaker
+        UChar_t intendedOrientation = (volume_id % 2 == 0) ? kFttVertical : kFttHorizontal;
+
+        if ( plane_id < 0 || plane_id >= (int)StFttDb::nPlane ) continue;
+
+        // GEANT truth global position, cm
+        double gx = git->x[0];
+        double gy = git->x[1];
+
+        // Brute force the quadrant: try all 4, invert
+        // StFttClusterPointMaker::MakeGlobalPoints()'s forward transform
+        // ( global = ((local*s)+d)/10 ) with the SAME live StFttDb call for each,
+        // and keep whichever gives a local (x,y) inside the physical strip range
+        // (0..~560mm). This makes the whole chain a self-consistent round trip
+        // through the real local<->global formula (whatever it currently is --
+        // bug or not, see status_ftt_sim_maker.txt), not an independently
+        // re-derived geometry. sx/sy are always +-1, so dividing == multiplying.
+        const double kLocalMax = 560.0; // mm, a bit above the largest strip-group edge (548.7mm)
+        int quadrant_id = -1;
+        double local_x = 0, local_y = 0;
+        for ( int q = 0; q < (int)StFttDb::nQuadPerPlane; q++ ) {
+            float dx, sx, dy, sy, dz, sz;
+            mFttDb->getGloablOffset_ClusterPoint( (UChar_t)plane_id, (UChar_t)q, dx, sx, dy, sy, dz, sz );
+            double lx = (gx * 10.0 - dx) * sx;
+            double ly = (gy * 10.0 - dy) * sy;
+            if ( lx >= 0 && lx <= kLocalMax && ly >= 0 && ly <= kLocalMax ) {
+                quadrant_id = q;
+                local_x = lx;
+                local_y = ly;
+                break;
+            }
+        }
+        if ( quadrant_id < 0 ) continue; // didn't land cleanly in any quadrant's valid local range
+
+        // Diagonal strips are a SECOND strip layer etched on the SAME foil as
+        // the primary (Vertical or Horizontal) one -- see StEnumerations.h's
+        // "diagonal strips on the vertical/horizontal chamber" comment and
+        // status_ftt_sim_maker.txt item 5 -- not a separate spatial zone, so
+        // try both from the same truth hit and inject whichever is valid.
+        UChar_t diagonalOrientation = ( kFttVertical == intendedOrientation ) ? kFttDiagonalV : kFttDiagonalH;
+        const UChar_t attempts[2] = { intendedOrientation, diagonalOrientation };
+
+        // Drawn ONCE per truth hit: intendedOrientation and diagonalOrientation
+        // are the same physical foil's two strip layers (Vertical+DiagonalV =
+        // front foil, Horizontal+DiagonalH = back foil), reading the same
+        // charge deposit -- see header comment on setMeanTotalAdc().
+        double totalAdc = -mMeanTotalAdc * std::log( gRandom->Rndm() );
+        const double kPitch = StFttDb::stripPitch;
+
+        bool anyBuilt = false;
+        for ( int a = 0; a < 2; a++ ) {
+            UChar_t orientation = attempts[a];
+            int row = -1, centerStrip = -1;
+            double subStripOffset = 0; // true hit position within the center strip, relative to its own center, mm
+            if ( !computeRowStrip( orientation, local_x, local_y, row, centerStrip, subStripOffset ) ) continue;
+
+            if ( mDebug ) {
+                printf( "StFttSimHitMaker DEBUG: track=%d plane=%d quad=%d orient=%d g=(%.3f,%.3f) local=(%.2f,%.2f) row=%d strip=%d off=%.2f\n",
+                        track_id, plane_id, quadrant_id, (int)orientation, gx, gy, local_x, local_y, row, centerStrip, subStripOffset );
+            }
+
+            anyBuilt = true;
+
+            // Real-data-based charge sharing (see header comment): split the
+            // shared total charge over center strip +-1 via a Gaussian(sigma)
+            // response integrated over each strip's bounds relative to the
+            // true sub-strip position -- an off-center hit naturally gets an
+            // asymmetric split, unlike a fixed ratio. Threshold is applied
+            // once, at final emission below, after summing all contributions
+            // per channel (center strip is always kept -- see header comment).
+            for ( int d = -1; d <= 1; d++ ) {
+                int strip = centerStrip + d;
+                if ( strip < 0 ) continue;
+                double lo = ( d - 0.5 ) * kPitch - subStripOffset;
+                double hi = ( d + 0.5 ) * kPitch - subStripOffset;
+                double frac = 0.5 * ( std::erf( hi / ( mChargeShareSigma * std::sqrt(2.0) ) )
+                                     - std::erf( lo / ( mChargeShareSigma * std::sqrt(2.0) ) ) );
+                float adc = (float)( totalAdc * frac );
+                accumulateStrip( accum, plane_id, quadrant_id, row, strip, adc, (UShort_t) track_id, orientation, ( 0 == d ) );
+            }
+        }
+        if ( anyBuilt ) nTruthHits++;
+    } // loop on geant hits
+
+    // Now that every truth hit's contribution to every channel has been
+    // summed (a channel near two nearby tracks' edges can clear threshold
+    // only once both contributions are added -- real hardware behavior),
+    // emit one StFttRawHit per channel that clears the hardware-like
+    // zero-suppression threshold -- EXCEPT a center (d==0) strip, which is
+    // always emitted (floored up to threshold if the draw came in low): see
+    // header comment on setStripAdcThreshold() for why (keeps efficiency at
+    // 100%, as this project's TODO deliberately still wants for now).
+    const float kMaxAdc = 1023.0f; // 10-bit ADC, matches StFttDb::maxADC-2
+    int nStripsAdded = 0;
+    for ( std::map<long long, ChannelAccum>::iterator it = accum.begin(); it != accum.end(); ++it ) {
+        ChannelAccum &c = it->second;
+        float adc = c.adcSum;
+        if ( adc < mStripAdcThreshold ) {
+            if ( !c.isCenter ) continue;
+            adc = mStripAdcThreshold;
+        }
+        if ( adc > kMaxAdc ) adc = kMaxAdc; // saturate, matches real hardware
+        size_t before = mFttCollection->rawHits().size();
+        addStrip( c.plane, c.quad, c.row, c.strip, adc, c.idTruth, c.orientation );
+        if ( mFttCollection->rawHits().size() > before ) nStripsAdded++;
+    }
+
+    LOG_INFO << "StFttSimHitMaker made " << nStripsAdded << " raw hits ("
+              << accum.size() << " unique channels) from "
+              << nTruthHits << " truth hits this event" << endm;
+
+    return kStOk;
+}
+
+//_____________________________________________________________
+// Invert the local-coordinate formula for the given orientation to get a
+// (row, strip) address, self-consistently with whatever the real code
+// computes forward:
+//   - kFttVertical/kFttHorizontal (rows 0-2): StFttClusterMaker::
+//     CalculateClusterInfo()'s x = strip*stripPitch - stripPitch/2 gives the
+//     measured axis; StFttDb::YX_StripGroupEdge bands the row axis into rows
+//     0/1/2.
+//   - kFttDiagonalV/kFttDiagonalH (rows 3-4): StFttClusterPointMaker::
+//     MakeLocalPoints()'s rotation x=a+(root2/2)(x'-y'), y=a+(root2/2)(x'+y')
+//     (a = StFttDb::D_StripGroupEdge[0]) inverts to x'=(x+y-2a)/root2,
+//     y'=(y-x)/root2; row 3 vs 4 is just the sign of y' (MakeLocalPoints
+//     negates y' for row==3, both DiagonalV and DiagonalH); x' feeds the same
+//     strip*pitch-pitch/2 inversion as X/Y.
+// Returns false if the position falls outside this orientation's coverage
+// (row 0-2 case) -- strip-range validity for either case is enforced later
+// by reverseHardwareMap() itself.
+bool StFttSimHitMaker::computeRowStrip( UChar_t orientation, double local_x, double local_y, int &row, int &centerStrip, double &subStripOffset )
+{
+    if ( kFttVertical == orientation || kFttHorizontal == orientation ) {
+        double measuredAxis = ( kFttVertical == orientation ) ? local_x : local_y;
+        double rowAxis      = ( kFttVertical == orientation ) ? local_y : local_x;
+
+        row = -1;
+        if      ( rowAxis >= StFttDb::YX_StripGroupEdge[2] ) row = 2;
+        else if ( rowAxis >= StFttDb::YX_StripGroupEdge[1] ) row = 1;
+        else if ( rowAxis >= StFttDb::YX_StripGroupEdge[0] ) row = 0;
+        if ( row < 0 ) return false; // falls inside the inner (beampipe-side) cutout
+
+        centerStrip = (int) std::lround( (measuredAxis + StFttDb::stripPitch / 2.0) / StFttDb::stripPitch );
+        // true hit position relative to centerStrip's own center (see header
+        // comment on setChargeShareSigma): centerStrip's center sits at
+        // (centerStrip-0.5)*stripPitch in this same measuredAxis coordinate.
+        subStripOffset = measuredAxis - ( centerStrip - 0.5 ) * StFttDb::stripPitch;
+        return centerStrip >= 0;
+    }
+
+    if ( kFttDiagonalV == orientation || kFttDiagonalH == orientation ) {
+        double a = StFttDb::D_StripGroupEdge[0];
+        double x_prime = (local_x + local_y - 2.0 * a) / std::sqrt(2.0);
+        double y_prime = (local_y - local_x) / std::sqrt(2.0);
+
+        // MakeLocalPoints() uses OPPOSITE row<->sign conventions for the two
+        // diagonal orientations: kFttDiagonalV negates y_prime on row==3 (so
+        // y_prime>=0 means row==4); kFttDiagonalH negates on row==4 (so
+        // y_prime>=0 means row==3). Getting this backwards still finds A
+        // valid (row,strip) via reverseHardwareMap() (row 3 and row 4 are
+        // both real, distinct hardware channels), just the WRONG one.
+        if ( kFttDiagonalV == orientation ) row = ( y_prime >= 0 ) ? 4 : 3;
+        else                                row = ( y_prime >= 0 ) ? 3 : 4;
+
+        centerStrip = (int) std::lround( (x_prime + StFttDb::stripPitch / 2.0) / StFttDb::stripPitch );
+        subStripOffset = x_prime - ( centerStrip - 0.5 ) * StFttDb::stripPitch;
+        return centerStrip >= 0;
+    }
+
+    return false;
+}
+
+//_____________________________________________________________
+// (plane,quad,row,strip) already uniquely identifies one real hardware
+// channel -- XY rows (0-2) and diagonal rows (3-4) are disjoint ranges, so
+// orientation doesn't need to be part of the key. Plain bit-packed (not
+// hashed) so it's trivially injective: plane needs 2 bits, quad 2, row 3,
+// strip 8 -- generous shifts below, no overlap.
+long long StFttSimHitMaker::packChannelKey( int plane, int quad, int row, int strip )
+{
+    return ( (long long)plane << 24 )
+         | ( (long long)quad  << 20 )
+         | ( (long long)row   << 12 )
+         | ( (long long)strip );
+}
+
+//_____________________________________________________________
+void StFttSimHitMaker::accumulateStrip( std::map<long long, ChannelAccum> &accum, int plane, int quad, int row, int strip, float adc, UShort_t idTruth, UChar_t orientation, bool isCenter )
+{
+    long long key = packChannelKey( plane, quad, row, strip );
+    ChannelAccum &c = accum[key]; // default-constructs on first touch of this channel
+    c.plane = plane; c.quad = quad; c.row = row; c.strip = strip; c.orientation = orientation;
+    c.adcSum += adc;
+    if ( isCenter ) c.isCenter = true; // sticky: stays true even if a later, non-center contribution touches this channel too
+    if ( adc > c.maxAdc ) { // dominant contributor's truth id represents the merged hit
+        c.maxAdc = adc;
+        c.idTruth = idTruth;
+    }
+}
+
+//_____________________________________________________________
+void StFttSimHitMaker::addStrip( int plane, int quad, int row, int strip, float adc, UShort_t idTruth, UChar_t expectOrientation )
+{
+    int rob = -1, feb = -1, vmm = -1, ch = -1;
+    // Pre-set orientation to the wanted value: reverseHardwareMap() now
+    // disambiguates the (row,strip) collision (both an H and a V -- or
+    // DiagonalH/DiagonalV -- channel exist there) using this as a hint.
+    UChar_t orientation = expectOrientation;
+    bool ok = mFttDb->reverseHardwareMap( rob, feb, vmm, ch, plane, quad, row, strip, orientation );
+    if ( !ok ) {
+        if ( mDebug ) {
+            LOG_INFO << "StFttSimHitMaker::addStrip - no hardware address for plane=" << plane
+                      << " quad=" << quad << " row=" << row << " strip=" << strip
+                      << " orientation=" << (int)expectOrientation << ", dropping" << endm;
+        }
+        return;
+    }
+
+    // reverseHardwareMap() returns feb/vmm in the table's 1-based convention;
+    // StFttRawHit stores them 0-based (StFttDb::hardwareMap() adds the +1 back
+    // when packing the key from a raw hit -- see StFttDb.cxx)
+    StFttRawHit *hit = new StFttRawHit( (UChar_t)(plane + 1), (UChar_t)(quad + 1),
+                                         (UChar_t)(feb - 1), (UChar_t)(vmm - 1), (UChar_t)ch,
+                                         (UShort_t)adc, /*bcid*/ 0, /*tb*/ 0, /*bcidDelta*/ 0 );
+    hit->setIdTruth( idTruth );
+    mFttCollection->addRawHit( hit );
+}

--- a/StRoot/StFttSimHitMaker/StFttSimHitMaker.h
+++ b/StRoot/StFttSimHitMaker/StFttSimHitMaker.h
@@ -1,0 +1,104 @@
+/***************************************************************************
+ * StFttSimHitMaker.h
+ ***************************************************************************
+ *
+ * Description: GEANT-truth -> StFttRawHit injector for testing the REAL
+ * StFttClusterMaker/StFttClusterPointMaker/StFttDb reconstruction chain with
+ * single-particle-gun (or any GEANT) MC, instead of the GEANT-truth blur
+ * used by StFttClusterPointMaker::MakeGeantPoints() / StFttFastSimMaker.
+ *
+ * Sits where StFttRawHitMaker + StFttHitCalibMaker normally would (both are
+ * real-DAQ/calibration specific and are skipped for simulated input): reads
+ * St_g2t_fts_hit truth hits, inverts StFttDb::getGloablOffset_ClusterPoint()
+ * to get the local (row, strip) address, and injects synthetic StFttRawHits
+ * (3-strip charge-sharing cluster) via StFttDb::reverseHardwareMap() so the
+ * unmodified, real StFttClusterMaker does the actual clustering.
+ *
+ * See proposal_ftt_sim_maker.txt (section 6) and status_ftt_sim_maker.txt
+ * for the full design/derivation and current status.
+ ***************************************************************************/
+#ifndef STFTTSIMHITMAKER_H
+#define STFTTSIMHITMAKER_H
+
+#include "StMaker.h"
+
+#ifndef __CINT__
+#include <map>
+#endif
+
+class StEvent;
+class StFttCollection;
+class StFttDb;
+
+class StFttSimHitMaker : public StMaker {
+public:
+    StFttSimHitMaker( const char* name = "fttSimHit" );
+    ~StFttSimHitMaker();
+
+    int Init();
+    int Make();
+
+    void SetDebug( int v = 1 ) { mDebug = v; }
+
+    // Real-data-based charge sharing (status_ftt_sim_maker.txt item 10):
+    // per-hit total charge drawn ONCE per truth hit (shared between the
+    // intended and diagonal orientation attempts -- they're the same
+    // physical foil's two strip layers reading the same charge deposit)
+    // from an exponential with mean=mMeanTotalAdc (measured sumAdc
+    // mean=RMS=~430-450, exponential-consistent), split over the true hit's
+    // own center strip +-1 via a Gaussian(sigma=mChargeShareSigma) response
+    // integrated over each strip's bounds (erf). Each candidate strip's
+    // SUMMED (across all truth hits landing on it) ADC is kept only if it
+    // clears mStripAdcThreshold -- EXCEPT the center (d==0) strip, which is
+    // always kept, floored up to mStripAdcThreshold if the draw came in low:
+    // a naive threshold on all 3 strips would silently drop ~30% of truth
+    // hits entirely (low-Q exponential draws), an unintended efficiency loss
+    // this project deliberately keeps at 100% for now (see status page TODO)
+    // -- only the neighbor strips' presence/absence should vary with Q and
+    // sub-strip position, giving realistic 1/2/3-strip multiplicity. Not
+    // meant to reproduce the measured profile beyond +-1 strip (that tail is
+    // small and likely pileup/noise-dominated in the busy real sample this
+    // was tuned from).
+    void setChargeShareSigma( float mm )   { mChargeShareSigma = mm; }
+    void setMeanTotalAdc( float adc )      { mMeanTotalAdc = adc; }
+    void setStripAdcThreshold( float adc ) { mStripAdcThreshold = adc; }
+
+private:
+    static bool computeRowStrip( UChar_t orientation, double local_x, double local_y, int &row, int &centerStrip, double &subStripOffset );
+    void addStrip( int plane, int quad, int row, int strip, float adc, UShort_t idTruth, UChar_t expectOrientation );
+
+#ifndef __CINT__
+    // A physical channel (plane,quad,row,strip) can receive contributions
+    // from more than one truth hit in the same event -- two nearby tracks,
+    // or one track's center strip landing on another's 10% neighbor spill
+    // -- important for high-occupancy/embedding studies (akio). ADC must be
+    // SUMMED per channel, exactly once per real hardware address, not left
+    // as separate StFttRawHit records at the same (feb,vmm,ch): a real DAQ
+    // channel reports one ADC value per event, and StFttClusterMaker's
+    // clustering isn't written to expect (nor reliably tolerate) duplicate
+    // entries at the same strip -- see status_ftt_sim_maker.txt item 9.
+    struct ChannelAccum {
+        int plane = 0, quad = 0, row = 0, strip = 0;
+        UChar_t orientation = 4; // kFttUnknownOrientation -- StEnumerations.h not included here
+        float adcSum = 0;
+        float maxAdc = -1;     // to pick the dominant contributor's truth id
+        UShort_t idTruth = 0;
+        bool isCenter = false; // true if ANY truth hit this event called this its own d==0 strip -- see setStripAdcThreshold() comment
+    };
+    static long long packChannelKey( int plane, int quad, int row, int strip );
+    void accumulateStrip( std::map<long long, ChannelAccum> &accum, int plane, int quad, int row, int strip, float adc, UShort_t idTruth, UChar_t orientation, bool isCenter );
+#endif
+
+    StEvent*         mEvent;         //! pointer to StEvent
+    StFttCollection* mFttCollection; //! pointer to StFttCollection
+    StFttDb*         mFttDb;         //! pointer to StFttDb
+
+    int   mDebug = 0;
+    float mChargeShareSigma  = 2.4;    // mm, fit to the measured nStrips==3 25:48:25 ratio
+    float mMeanTotalAdc      = 431.5;  // measured cluster sumAdc mean
+    float mStripAdcThreshold = 70.0;   // ~ observed hardware zero-suppression edge
+
+    ClassDef( StFttSimHitMaker, 0 )
+};
+
+#endif // STFTTSIMHITMAKER_H

--- a/StRoot/StFwdTrackMaker/include/Tracker/FwdTracker.h
+++ b/StRoot/StFwdTrackMaker/include/Tracker/FwdTracker.h
@@ -2235,12 +2235,14 @@ class ForwardTrackMaker {
         double horizontalMin_dy = 99;
         double horizontalMin_dr = 99;
         double horizontalMin_dp = 99;
+        double horizontalMin_hsx = 0; // matched hit's own along-strip (x) uncertainty
         KiTrack::IHit *horizontalClosest = nullptr;
 
         double verticalMin_dx = 99;
         double verticalMin_dy = 99;
         double verticalMin_dr = 99;
         double verticalMin_dp = 99;
+        double verticalMin_hsy = 0; // matched hit's own along-strip (y) uncertainty
         KiTrack::IHit *verticalClosest = nullptr;
 
         for (auto h : available_hits) {
@@ -2280,6 +2282,7 @@ class ForwardTrackMaker {
                     horizontalMin_dx = sx;
                     horizontalMin_dy = sy;
                     horizontalMin_dr = sr;
+                    horizontalMin_hsx = hsx;
                 }
             } else if ( hsy > hsx ){ // vertical strip
                 if ( sx < verticalMin_dx ){
@@ -2288,6 +2291,7 @@ class ForwardTrackMaker {
                     verticalMin_dx = sx;
                     verticalMin_dy = sy;
                     verticalMin_dr = sr;
+                    verticalMin_hsy = hsy;
                 }
             } else {
                 LOG_WARN << "Hit with equal covariance in x and y, skipping" << endm;
@@ -2297,16 +2301,31 @@ class ForwardTrackMaker {
         } // loop h
 
         // check threshold and add the closest horizontal strip hit
-        // Fix (Issue #3/4/7): gate on the precision coordinate (|dy|) instead of
-        // dPhi, and use && instead of || so a hit isn't accepted just because one
-        // coordinate happened to pass while the other was far off (up to ~16 cm).
-        if ( horizontalMin_dy < thresholdY && fabs(horizontalMin_dr) < thresholdR ) {
+        // Fix (Issue #3/4/7, 2026-07-10): gate on the precision coordinate (|dy|)
+        // instead of dPhi, and use && instead of || so a hit isn't accepted just
+        // because one coordinate happened to pass while the other was far off.
+        //
+        // Fix (2026-07-18): that 2026-07-10 fix removed the dPhi gate (it was too
+        // tight for wide strips) but never replaced it with anything constraining
+        // the off-axis coordinate (dx for H strips, dy for V strips) -- it was left
+        // completely free, gated only by thresholdR, which is a difference of
+        // R=sqrt(x^2+y^2) from the beamline, not a 2D distance, and is blind to
+        // azimuthal (phi) separation entirely. Gate the off-axis coordinate against
+        // that specific hit's own reported along-strip uncertainty (hsx/hsy,
+        // already computed above for orientation classification, just never used
+        // for gating) instead -- a hit's own sigma is the physically correct scale
+        // for "how far off-axis is still plausible for this strip", unlike a fixed
+        // global angular or radial constant.
+        const double kOffAxisNSigma = 3.0;
+        if ( horizontalMin_dy < thresholdY && fabs(horizontalMin_dr) < thresholdR
+             && horizontalMin_dx < kOffAxisNSigma * horizontalMin_hsx ) {
             found_hits.push_back(horizontalClosest);
             LOG_INFO << "Adding horizontal strip hit with dPhi = " << horizontalMin_dp << ", dR = " << horizontalMin_dr << ", dx = " << horizontalMin_dx << ", dy = " << horizontalMin_dy << endm;
         }
 
         // check threshold and add the closest vertical strip hit
-        if ( verticalMin_dx < thresholdX && fabs(verticalMin_dr) < thresholdR ) {
+        if ( verticalMin_dx < thresholdX && fabs(verticalMin_dr) < thresholdR
+             && verticalMin_dy < kOffAxisNSigma * verticalMin_hsy ) {
             found_hits.push_back(verticalClosest);
             LOG_INFO << "Adding vertical strip hit with dPhi = " << verticalMin_dp << ", dR = " << verticalMin_dr << ", dx = " << verticalMin_dx << ", dy = " << verticalMin_dy << endm;
         }

--- a/StRoot/StFwdTrackMaker/macro/mudst/fwd_afterburner.C
+++ b/StRoot/StFwdTrackMaker/macro/mudst/fwd_afterburner.C
@@ -127,7 +127,9 @@ void fwd_afterburner( 	const Char_t * fileList = "st_physics_23037002_raw_100006
 		
 		StFcsWaveformFitMaker *fcsWFF = new StFcsWaveformFitMaker();
 		// This should only be used for simulated data, for real data this done in the database
-		// fcsWFF->setEnergySelect(0);
+		//fcsWFF->setEnergySelect(0);
+		// This skips waveform analysis, and only apply new gain from DB
+		fcsWFF->setAnaWaveform(false);
 		StFcsClusterMaker *fcsclu = new StFcsClusterMaker();
 	}
 	/*******************************************************************************************/

--- a/StRoot/StFwdTrackMaker/macro/mudst/fwd_afterburner_db.C
+++ b/StRoot/StFwdTrackMaker/macro/mudst/fwd_afterburner_db.C
@@ -133,7 +133,7 @@ void fwd_afterburner_db(const Char_t * fileList = "root://xrdstar.rcf.bnl.gov:10
 		chain->AddMaker(fttDbMk);
 		StFttHitCalibMaker * ftthcm = new StFttHitCalibMaker();
 		StFttClusterMaker * fttclu = new StFttClusterMaker();
-		fttclu->SetTimeCut(1, -40, 40);
+		fttclu->SetTimeCut(2, -40, 100); // kTimeCutModeCalibratedTime, window from Run22-Run24 online QA (was mode 1 = AcceptAll, -40,40)
 		StFttClusterPointMaker *fttCP = new StFttClusterPointMaker();
 		// StFttPointMaker * fttpoint = new StFttPointMaker();
 	}

--- a/StRoot/StFwdTrackMaker/macro/mudst/fwd_afterburner_db.C
+++ b/StRoot/StFwdTrackMaker/macro/mudst/fwd_afterburner_db.C
@@ -147,7 +147,9 @@ void fwd_afterburner_db(const Char_t * fileList = "root://xrdstar.rcf.bnl.gov:10
 		
 		StFcsWaveformFitMaker *fcsWFF = new StFcsWaveformFitMaker();
 		// This should only be used for simulated data, for real data this done in the database
-		// fcsWFF->setEnergySelect(0);
+		//fcsWFF->setEnergySelect(0);
+		// This skips waveform analysis, and only apply new gain from DB
+		fcsWFF->setAnaWaveform(false);
 		StFcsClusterMaker *fcsclu = new StFcsClusterMaker();
 	}
 	/*******************************************************************************************/

--- a/StRoot/StFwdTrackMaker/macro/sim/sim.C
+++ b/StRoot/StFwdTrackMaker/macro/sim/sim.C
@@ -12,6 +12,13 @@ bool RunFwdChain = true;
 bool RunMuDstMaker = true;
 bool RunPicoWrite = true;
 
+// Real StFttDb reconstruction chain (StFttDbMaker -> StFttSimHitMaker ->
+// StFttClusterMaker -> StFttClusterPointMaker, mUseGeantData=false) in
+// place of reading GEANT truth directly (MakeGeantPoints, mUseGeantData=
+// true) -- exercises the same geometry/clustering code real data uses.
+// Set false for the old/original GEANT-truth-direct behavior.
+bool UseFttSimHitMaker = true;
+
 bool UseCachedGeom = true;
 bool UseConstBz = false;
 bool UseZeroB = false;
@@ -131,14 +138,45 @@ void sim(   char *inFile =  "/gpfs01/star/pwg/mrosales/jetFinderTest2024/star-sw
         }
     }
 
-    gSystem->Load( "StFttDbMaker" );
-    gSystem->Load( "libStFttSimMaker" );
-    gSystem->Load( "libStFttClusterPointMaker" );
-    // make an StFttClusterPointMaker
-    StFttClusterPointMaker * fttClusterPointMaker = new StFttClusterPointMaker("fttClusterPointMaker");
-    fttClusterPointMaker->SetDebug(1);
-    fttClusterPointMaker->setUseGeantData( true );
-    chain->AddBefore("fwdTrack", fttClusterPointMaker);
+    if ( UseFttSimHitMaker ) {
+        // Real chain: StFttDbMaker -> StFttSimHitMaker -> StFttClusterMaker ->
+        // StFttClusterPointMaker (mUseGeantData=false), same makers/order as
+        // fwd_afterburner_db.C's real-data chain, with StFttSimHitMaker in
+        // place of StFttRawHitMaker/StFttHitCalibMaker.
+        gSystem->Load( "libStFttDbMaker.so" );
+        gSystem->Load( "libStFttSimHitMaker.so" );
+        gSystem->Load( "libStFttClusterMaker.so" );
+        gSystem->Load( "libStFttClusterPointMaker.so" );
+
+        StFttDbMaker * fttDbMk = new StFttDbMaker();
+        chain->AddMaker(fttDbMk);
+
+        StFttSimHitMaker * fttSimHit = new StFttSimHitMaker();
+        chain->AddMaker(fttSimHit);
+
+        StFttClusterMaker * fttClu = new StFttClusterMaker();
+        fttClu->SetTimeCut( 1 /*kTimeCutModeAcceptAll*/, -9999, 9999 ); // no real timing in MC
+        chain->AddMaker(fttClu);
+
+        StFttClusterPointMaker * fttClusterPointMaker = new StFttClusterPointMaker("fttClusterPointMaker");
+        fttClusterPointMaker->SetDebug(1);
+        // mUseGeantData left at its constructor default (false) -- take the
+        // real MakeLocalPoints/MakeGlobalPoints path through StFttDb.
+        chain->AddBefore("fwdTrack", fttClusterPointMaker);
+    } else {
+        // Old/original behavior: read GEANT truth directly in global
+        // coordinates (StFttClusterPointMaker::MakeGeantPoints()) -- never
+        // calls into StFttDb's real geometry transform. Kept for backward
+        // compatibility (UseFttSimHitMaker = false).
+        gSystem->Load( "StFttDbMaker" );
+        gSystem->Load( "libStFttSimMaker" );
+        gSystem->Load( "libStFttClusterPointMaker" );
+
+        StFttClusterPointMaker * fttClusterPointMaker = new StFttClusterPointMaker("fttClusterPointMaker");
+        fttClusterPointMaker->SetDebug(1);
+        fttClusterPointMaker->setUseGeantData( true );
+        chain->AddBefore("fwdTrack", fttClusterPointMaker);
+    }
         
     // Configure the Forward Tracker
     if (RunFwdChain) {


### PR DESCRIPTION
- **Fix FTT off-axis matching**: `StFttClusterPointMaker::MakeGlobalPoints()` never
    rescaled hit covariance from mm² to cm² even though it rescales position (10x error
    on sigma for every FTT hit ever fit); `StFttCluster::maxStripCenter()` was never set
    by `StFttClusterMaker`, so the off-axis coordinate fell back to a row-averaged
    constant instead of the real per-strip center; and
    `findFttStripsNearProjectedState()` did not gated the off-axis coordinate at all after
    the 2026-07-10 dPhi-gate removal (debug#3/4/7).
  - **StFttDb::reverseHardwareMap**: support multiple channels per (row,strip) -- a
    single (row,strip) has both an H and V (or diagonal) channel in the real hardware
    map; the old plain map silently kept only the last-loaded one.
  - **Add StFttSimHitMaker**: From G2T hits for FTT, creating StFttRawHit so the real StFttClusterMaker/StFttClusterPointMaker (using StFttDb) chain runs on MC. 
  - **Afterburner speedup**: `StFcsWaveformFitMaker` was ~43% of total CPU time in
    real-data afterburner runs; `setAnaWaveform(false)` skips full waveform analysis and
    just applies the gain from the DB. Dropped to ~0.1% after the change. Applied to
    both `fwd_afterburner_db.C` and `fwd_afterburner.C`.