### PR TITLE
StFstHitMaker: fix global hit position after the local-position change

### DIFF
--- a/StRoot/StFstHitMaker/StFstHitMaker.cxx
+++ b/StRoot/StFstHitMaker/StFstHitMaker.cxx
@@ -198,10 +198,6 @@ Int_t StFstHitMaker::Make()
 				TGeoHMatrix *geoMSensorOnGlobal = (TGeoHMatrix *) mSensorTransforms->FindObject(Form("R%04i", sensorId));
 				geoMSensorOnGlobal->LocalToMaster(local, global);
 
-                                global[0] = local[0]*cos(local[1]);
-                                global[1] = local[0]*sin(local[1]);
-                                global[2] = local[2];
-
 				StThreeVectorF vecGlobal(global);
 				newHit->setPosition(vecGlobal); //set global position
 			}//end sensor hit collection

--- a/StRoot/StFwdTrackMaker/StFwdHitLoader.cxx
+++ b/StRoot/StFwdTrackMaker/StFwdHitLoader.cxx
@@ -359,9 +359,16 @@ int StFwdHitLoader::loadFstHitsFromMuDst( FwdDataSource::McTrackMap_t &mcTrackMa
     for ( unsigned int index = 0; index < fst->numberOfHits(); index++){
         StMuFstHit * muFstHit = fst->getHit( index );
 
-        float vR = muFstHit->localPosition(0);
-        float vPhi = muFstHit->localPosition(1);
-        float vZ = muFstHit->localPosition(2);
+        // Take the stored GLOBAL position, do not rebuild it from localPosition.
+        // Since 9e70bfd0a9 localPosition is sensor-local CARTESIAN, so treating
+        // [0],[1] as (r,phi) and taking cos/sin of them is meaningless. xyz() is
+        // correct both for files written before that change and after it
+        // (verified equal to the old r*cos/sin to 1e-6 cm on production
+        // run 23081008, 19942 hits).
+        const TVector3 &gpos = muFstHit->xyz();
+        float x0 = gpos.X();
+        float y0 = gpos.Y();
+        float vZ = gpos.Z();
 
         int diskIndex   = muFstHit->getDisk() - 1;                                    // getDisk() is 1-indexed; convert to 0-indexed
         int wedgeIndex  = (muFstHit->getWedge() - 1) % kFstNumWedgePerDisk;           // getWedge() is global 1-indexed (1-36); convert to per-disk 0-indexed (0-11)
@@ -369,11 +376,9 @@ int StFwdHitLoader::loadFstHitsFromMuDst( FwdDataSource::McTrackMap_t &mcTrackMa
         int globalIndex = FwdHit::fstGlobalSensorIndex( diskIndex, wedgeIndex, sensorIndex );
         if ( kLogLevel >= kLogVerbose ) {LOG_INFO << "wedgeIndex: " << wedgeIndex << ", sensorIndex: " << sensorIndex << ", diskIndex: " << diskIndex << ", globalIndex: " << globalIndex << endm;}
 
-        float x0 = vR * cos( vPhi );
-        float y0 = vR * sin( vPhi );
         hitCov3 = makeFstCovMat( TVector3( x0, y0, vZ ) );
         mSpacepointsFst.push_back( TVector3( x0, y0, vZ)  );
-        if ( kLogLevel >= kLogVerbose ) {LOG_INFO << TString::Format("FST local position: %f %f %f, global position: %f %f %f", vR, vPhi, vZ, x0, y0, vZ) << endm;}
+        if ( kLogLevel >= kLogVerbose ) {LOG_INFO << TString::Format("FST global position: %f %f %f", x0, y0, vZ) << endm;}
 
         // we use d+4 so that both FTT and FST start at 4
         mFwdHitsFst.push_back(
@@ -435,10 +440,13 @@ int StFwdHitLoader::loadFstHitsFromStEvent( FwdDataSource::McTrackMap_t &mcTrack
                 if ( !sc ) continue;
                 StSPtrVecFstHit fsthits = sc->hits();
                 for ( unsigned int ih = 0; ih < fsthits.size(); ih++ ){
-                    float vR   = fsthits[ih]->localPosition(0);
-                    float vPhi = fsthits[ih]->localPosition(1);
-                    float vZ   = fsthits[ih]->localPosition(2);
-                    if ( kLogLevel >= kLogInfo ){LOG_INFO << TString::Format("FST local position: %f %f %f", vR, vPhi, vZ) << endm;}
+                    // Global position, not localPosition -- see the note in
+                    // loadFstHitsFromMuDst above.
+                    const StThreeVectorF &gpos = fsthits[ih]->position();
+                    float x0   = gpos.x();
+                    float y0   = gpos.y();
+                    float vZ   = gpos.z();
+                    if ( kLogLevel >= kLogInfo ){LOG_INFO << TString::Format("FST global position: %f %f %f", x0, y0, vZ) << endm;}
                     
                     int wedgeIndex  = iw % kFstNumWedgePerDisk;
                     int sensorIndex = is % kFstNumSensorsPerWedge;
@@ -446,8 +454,6 @@ int StFwdHitLoader::loadFstHitsFromStEvent( FwdDataSource::McTrackMap_t &mcTrack
                     int globalIndex = FwdHit::fstGlobalSensorIndex( diskIndex, wedgeIndex, sensorIndex );
 
                     if ( kLogLevel >= kLogVerbose ) {LOG_INFO << "diskIndex = " << diskIndex << ", wedgeIndex = " << wedgeIndex << ", sensorIndex = " << sensorIndex << ", globalIndex = " << globalIndex << endm;}
-                    float x0 = vR * cos( vPhi );
-                    float y0 = vR * sin( vPhi );
                     hitCov3 = makeFstCovMat( TVector3( x0, y0, vZ ) );
 
                        


### PR DESCRIPTION
Commit 9e70bfd0a9 changed setLocalPosition() to store true sensor-local CARTESIAN coordinates, obtained with MasterToLocal():

    g[0] = local[0]*cos(local[1]);          // global (r,phi,z) -> cartesian
    g[1] = local[0]*sin(local[1]);
    g[2] = local[2];
    geoMSensor->MasterToLocal(g, l);
    newHit->setLocalPosition(l[0], l[1], l[2]);

but the code that sets the GLOBAL position ~25 lines later was not updated. It still converts localPosition(0),localPosition(1) as if they were the polar (r,phi) of the OLD convention:

    geoMSensorOnGlobal->LocalToMaster(local, global);   // correct result...
    global[0] = local[0]*cos(local[1]);                 // ...immediately discarded
    global[1] = local[0]*sin(local[1]);
    global[2] = local[2];

Taking cos/sin of a cartesian y coordinate is meaningless, so every FST global position has been wrong since then. Reconstructed hits come out at radii of ~1 cm, inside the detector's 5 cm inner edge.

The fix is to delete the three overwrite lines and keep the LocalToMaster() result that is already computed on the line above.

This is a pure bug fix, not a behaviour change. The producer applies MasterToLocal and the consumer applies LocalToMaster using the SAME matrix (same sensorId, same mSensorTransforms entry), so the round trip is the identity and the global position returns to exactly the value the pre-9e70bfd0a9 code produced. In particular this does NOT start applying the DB/survey alignment -- the two transforms cancel, before and after this change. What is gained is that localPosition() is now cartesian, as intended, AND the global position is correct again.

Verified on a 1.5 GeV single-electron MC gun run through fstRawHit -> fstCluster -> fstHit:

    local            = (4.76567, 5.06752)      cartesian, sensor frame
    LocalToMaster -> = (4.52398, 4.57984)      r = 6.4375 cm, phi = 45.35 deg
    expected r       = kFstrStart[0] + 0.5*kFstStripPitchR = 6.4375 cm   OK

and over 200 events the reconstructed-vs-GEANT residuals become dr RMS 0.799 cm (strip quantization is 2.875/sqrt(12) = 0.830) and r*dphi RMS 0.084 cm, against 1.105 cm and 2.259 cm before the fix.

The bug stayed hidden because nothing exercised StFstHitMaker on MC -- the fast simulator bypasses it, and real-data analyses read pre-produced MuDst.